### PR TITLE
some more fixes

### DIFF
--- a/src/CompositionRoot.ts
+++ b/src/CompositionRoot.ts
@@ -67,6 +67,7 @@ import { GetConfigurationsUseCase } from "./domain/usecases/GetConfigurationsUse
 import { ConfigurationsRepository } from "./domain/repositories/ConfigurationsRepository";
 import { ConfigurationsD2Repository } from "./data/repositories/ConfigurationsD2Repository";
 import { ConfigurationsTestRepository } from "./data/repositories/test/ConfigurationsTestRepository";
+import { CompleteEventTrackerUseCase } from "./domain/usecases/CompleteEventTrackerUseCase";
 
 export type CompositionRoot = ReturnType<typeof getCompositionRoot>;
 
@@ -106,6 +107,7 @@ function getCompositionRoot(repositories: Repositories) {
                 repositories.configurationsRepository,
                 repositories.teamMemberRepository
             ),
+            complete: new CompleteEventTrackerUseCase(repositories),
         },
         incidentActionPlan: {
             get: new GetIncidentActionByIdUseCase(repositories),

--- a/src/data/repositories/test/DiseaseOutbreakEventTestRepository.ts
+++ b/src/data/repositories/test/DiseaseOutbreakEventTestRepository.ts
@@ -10,6 +10,9 @@ import { DiseaseOutbreakEventRepository } from "../../../domain/repositories/Dis
 import { FutureData } from "../../api-futures";
 
 export class DiseaseOutbreakEventTestRepository implements DiseaseOutbreakEventRepository {
+    complete(id: Id): FutureData<void> {
+        return Future.success(undefined);
+    }
     get(id: Id): FutureData<DiseaseOutbreakEventBaseAttrs> {
         return Future.success({
             id: id,

--- a/src/domain/repositories/DiseaseOutbreakEventRepository.ts
+++ b/src/domain/repositories/DiseaseOutbreakEventRepository.ts
@@ -1,10 +1,10 @@
 import { FutureData } from "../../data/api-futures";
 import { DiseaseOutbreakEventBaseAttrs } from "../entities/disease-outbreak-event/DiseaseOutbreakEvent";
-import { ConfigLabel, Id } from "../entities/Ref";
+import { Id } from "../entities/Ref";
 
 export interface DiseaseOutbreakEventRepository {
     get(id: Id): FutureData<DiseaseOutbreakEventBaseAttrs>;
     getAll(): FutureData<DiseaseOutbreakEventBaseAttrs[]>;
     save(diseaseOutbreak: DiseaseOutbreakEventBaseAttrs): FutureData<Id>;
-    getConfigStrings(): FutureData<ConfigLabel[]>;
+    complete(id: Id): FutureData<void>;
 }

--- a/src/domain/usecases/CompleteEventTrackerUseCase.ts
+++ b/src/domain/usecases/CompleteEventTrackerUseCase.ts
@@ -1,0 +1,15 @@
+import { FutureData } from "../../data/api-futures";
+import { Id } from "../entities/Ref";
+import { DiseaseOutbreakEventRepository } from "../repositories/DiseaseOutbreakEventRepository";
+
+export class CompleteEventTrackerUseCase {
+    constructor(
+        private options: {
+            diseaseOutbreakEventRepository: DiseaseOutbreakEventRepository;
+        }
+    ) {}
+
+    public execute(id: Id): FutureData<void> {
+        return this.options.diseaseOutbreakEventRepository.complete(id);
+    }
+}

--- a/src/domain/usecases/GetDiseaseOutbreakByIdUseCase.ts
+++ b/src/domain/usecases/GetDiseaseOutbreakByIdUseCase.ts
@@ -10,8 +10,6 @@ import { OrgUnitRepository } from "../repositories/OrgUnitRepository";
 import { RiskAssessmentRepository } from "../repositories/RiskAssessmentRepository";
 import { RoleRepository } from "../repositories/RoleRepository";
 import { TeamMemberRepository } from "../repositories/TeamMemberRepository";
-import { getIncidentAction } from "./utils/incident-action/GetIncidentActionById";
-import { getIncidentManagementTeamById } from "./utils/incident-management-team/GetIncidentManagementTeamById";
 import { getAll } from "./utils/risk-assessment/GetRiskAssessmentById";
 
 export class GetDiseaseOutbreakByIdUseCase {
@@ -62,18 +60,8 @@ export class GetDiseaseOutbreakByIdUseCase {
                         this.options.riskAssessmentRepository,
                         configurations
                     ),
-                    incidentAction: getIncidentAction(
-                        id,
-                        this.options.incidentActionRepository,
-                        configurations
-                    ),
-                    incidentManagementTeam: getIncidentManagementTeamById(
-                        id,
-                        this.options,
-                        configurations
-                    ),
                     roles: this.options.roleRepository.getAll(),
-                }).flatMap(({ riskAssessment, incidentAction, incidentManagementTeam, roles }) => {
+                }).flatMap(({ riskAssessment, roles }) => {
                     return this.options.incidentManagementTeamRepository
                         .getIncidentManagementTeamMember(incidentManagerName, id, roles)
                         .flatMap(incidentManager => {
@@ -86,8 +74,8 @@ export class GetDiseaseOutbreakByIdUseCase {
                                     notificationSource: notificationSource,
                                     incidentManager: incidentManager,
                                     riskAssessment: riskAssessment,
-                                    incidentActionPlan: incidentAction,
-                                    incidentManagementTeam: incidentManagementTeam,
+                                    incidentActionPlan: undefined, //IAP is fetched on menu click. It is not needed here.
+                                    incidentManagementTeam: undefined, //IMT is fetched on menu click. It is not needed here.
                                 });
                             return Future.success(diseaseOutbreakEvent);
                         });

--- a/src/webapp/components/form/form-summary/EventTrackerFormSummary.tsx
+++ b/src/webapp/components/form/form-summary/EventTrackerFormSummary.tsx
@@ -6,14 +6,16 @@ import { Box, Button, Typography } from "@material-ui/core";
 import { UserCard } from "../../user-selector/UserCard";
 import { RouteName, useRoutes } from "../../../hooks/useRoutes";
 import { EditOutlined } from "@material-ui/icons";
+import { CheckOutlined } from "@material-ui/icons";
 import { Loader } from "../../loader/Loader";
 import { useSnackbar } from "@eyeseetea/d2-ui-components";
 import { FormSummaryData } from "../../../pages/event-tracker/useDiseaseOutbreakEvent";
 import { Maybe } from "../../../../utils/ts-utils";
 import { FormType } from "../../../pages/form-page/FormPage";
 import { Id } from "../../../../domain/entities/Ref";
+import { useAppContext } from "../../../contexts/app-context";
 
-export type FormSummaryProps = {
+export type EventTrackerFormSummaryProps = {
     id: Id;
     formType: FormType;
     formSummary: Maybe<FormSummaryData>;
@@ -22,7 +24,8 @@ export type FormSummaryProps = {
 
 const ROW_COUNT = 3;
 
-export const FormSummary: React.FC<FormSummaryProps> = React.memo(props => {
+export const EventTrackerFormSummary: React.FC<EventTrackerFormSummaryProps> = React.memo(props => {
+    const { compositionRoot } = useAppContext();
     const { id, formType, formSummary, summaryError } = props;
     const { goTo } = useRoutes();
     const snackbar = useSnackbar();
@@ -38,6 +41,18 @@ export const FormSummary: React.FC<FormSummaryProps> = React.memo(props => {
         goTo(RouteName.EDIT_FORM, { formType: formType, id: id });
     }, [formType, goTo, id]);
 
+    const onCompleteClick = useCallback(() => {
+        compositionRoot.diseaseOutbreakEvent.complete.execute(id).run(
+            () => {
+                snackbar.success(i18n.t("Event completed"));
+            },
+            err => {
+                snackbar.error(i18n.t(`Failed to complete event: ${err.message}`));
+                console.error(err);
+            }
+        );
+    }, []);
+
     const editButton = (
         <Button
             variant="outlined"
@@ -46,6 +61,17 @@ export const FormSummary: React.FC<FormSummaryProps> = React.memo(props => {
             startIcon={<EditOutlined />}
         >
             {i18n.t("Edit Details")}
+        </Button>
+    );
+
+    const completeButton = (
+        <Button
+            variant="outlined"
+            color="secondary"
+            onClick={onCompleteClick}
+            startIcon={<CheckOutlined />}
+        >
+            {i18n.t("Complete Event")}
         </Button>
     );
 
@@ -66,6 +92,7 @@ export const FormSummary: React.FC<FormSummaryProps> = React.memo(props => {
                 title={formSummary.subTitle}
                 hasSeparator={true}
                 headerButton={editButton}
+                secondaryHeaderButton={completeButton}
                 titleVariant="secondary"
             >
                 <SummaryContainer>

--- a/src/webapp/components/section/Section.tsx
+++ b/src/webapp/components/section/Section.tsx
@@ -9,6 +9,7 @@ type SectionProps = {
     lastUpdated?: string;
     children: React.ReactNode;
     headerButton?: React.ReactNode;
+    secondaryHeaderButton?: React.ReactNode;
     hasSeparator?: boolean;
     titleVariant?: "primary" | "secondary";
 };
@@ -18,6 +19,7 @@ export const Section: React.FC<SectionProps> = React.memo(
         title = "",
         lastUpdated = "",
         headerButton,
+        secondaryHeaderButton,
         hasSeparator = false,
         children,
         titleVariant = "primary",
@@ -40,7 +42,10 @@ export const Section: React.FC<SectionProps> = React.memo(
                         ) : null}
                     </TitleContainer>
 
-                    {headerButton ? <div>{headerButton}</div> : null}
+                    <ButtonContainer>
+                        {headerButton ? <div>{headerButton}</div> : null}
+                        {secondaryHeaderButton ? <div>{secondaryHeaderButton}</div> : null}
+                    </ButtonContainer>
                 </Header>
 
                 <Content>{children}</Content>
@@ -48,7 +53,10 @@ export const Section: React.FC<SectionProps> = React.memo(
         );
     }
 );
-
+const ButtonContainer = styled.div`
+    display: flex;
+    gap: 5px;
+`;
 const SectionContainer = styled.section<{ $hasSeparator?: boolean }>`
     width: 100%;
     margin-block-end: ${props => (props.$hasSeparator ? "0" : "24px")};

--- a/src/webapp/pages/event-tracker/EventTrackerPage.tsx
+++ b/src/webapp/pages/event-tracker/EventTrackerPage.tsx
@@ -5,7 +5,7 @@ import { useParams } from "react-router-dom";
 import { AddCircleOutline, EditOutlined } from "@material-ui/icons";
 import i18n from "../../../utils/i18n";
 import { Layout } from "../../components/layout/Layout";
-import { FormSummary } from "../../components/form/form-summary/FormSummary";
+import { EventTrackerFormSummary } from "../../components/form/form-summary/EventTrackerFormSummary";
 import { Chart } from "../../components/chart/Chart";
 import { Section } from "../../components/section/Section";
 import { BasicTable, TableColumn } from "../../components/table/BasicTable";
@@ -69,7 +69,7 @@ export const EventTrackerPage: React.FC = React.memo(() => {
 
     return (
         <Layout title={i18n.t("Event Tracker")} lastAnalyticsRuntime={lastAnalyticsRuntime}>
-            <FormSummary
+            <EventTrackerFormSummary
                 id={id}
                 formType="disease-outbreak-event"
                 formSummary={formSummary}


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #?

### :memo: Implementation

- [ ] perf improvement  - do not fetch IAP, IMT on event tracker page load as it is not used. They are fetched on menu click, so this earlier call is redundant.
- [ ] rename summary file with better name
- [ ] add complete event feature

### :video_camera: Screenshots/Screen capture

### :fire: Notes to the tester
