### PR TITLE
fix: show only items with "ALL" incident status

### DIFF
--- a/src/data/repositories/PerformanceOverviewD2Repository.ts
+++ b/src/data/repositories/PerformanceOverviewD2Repository.ts
@@ -188,8 +188,10 @@ export class PerformanceOverviewD2Repository implements PerformanceOverviewRepos
 
         const filteredCounts: TotalCardCounts[] = counts.filter(item => {
             if (filters && Object.entries(filters).length) {
-                const matchesDisease = !filters.disease || item.name === filters.disease;
-                const matchesHazard = !filters.hazard || item.type === "hazard";
+                const matchesDisease =
+                    !filters.disease || (item.type === "disease" && item.name === filters.disease);
+                const matchesHazard =
+                    !filters.hazard || (item.type === "hazard" && item.name === filters.hazard);
                 const matchesIncidentStatus = !filters.incidentStatus
                     ? item.incidentStatus === "ALL"
                     : item.incidentStatus === filters.incidentStatus;

--- a/src/data/repositories/PerformanceOverviewD2Repository.ts
+++ b/src/data/repositories/PerformanceOverviewD2Repository.ts
@@ -109,7 +109,7 @@ export class PerformanceOverviewD2Repository implements PerformanceOverviewRepos
                         existingEntry.total += totalCardCount.total;
                         acc[totalCardCount.name] = existingEntry;
                     } else {
-                        acc[totalCardCount.name] = totalCardCount;
+                        acc[totalCardCount.name] = { ...totalCardCount };
                     }
                     return acc;
                 }, {} as Record<string, TotalCardCounts>);
@@ -190,7 +190,7 @@ export class PerformanceOverviewD2Repository implements PerformanceOverviewRepos
             if (filters && Object.entries(filters).length) {
                 return Object.entries(filters).every(([key, value]) => {
                     if (!value) {
-                        return true;
+                        return item.incidentStatus === "ALL";
                     }
                     if (key === "incidentStatus") {
                         return value === item.incidentStatus;

--- a/src/data/repositories/PerformanceOverviewD2Repository.ts
+++ b/src/data/repositories/PerformanceOverviewD2Repository.ts
@@ -188,16 +188,13 @@ export class PerformanceOverviewD2Repository implements PerformanceOverviewRepos
 
         const filteredCounts: TotalCardCounts[] = counts.filter(item => {
             if (filters && Object.entries(filters).length) {
-                return Object.entries(filters).every(([key, value]) => {
-                    if (!value) {
-                        return item.incidentStatus === "ALL";
-                    }
-                    if (key === "incidentStatus") {
-                        return value === item.incidentStatus;
-                    } else if (key === "disease" || key === "hazard") {
-                        return value === item.name;
-                    }
-                });
+                const matchesDisease = !filters.disease || item.name === filters.disease;
+                const matchesHazard = !filters.hazard || item.type === "hazard";
+                const matchesIncidentStatus = !filters.incidentStatus
+                    ? item.incidentStatus === "ALL"
+                    : item.incidentStatus === filters.incidentStatus;
+
+                return matchesDisease && matchesHazard && matchesIncidentStatus;
             }
             return true;
         });

--- a/src/domain/entities/disease-outbreak-event/PerformanceOverviewMetrics.ts
+++ b/src/domain/entities/disease-outbreak-event/PerformanceOverviewMetrics.ts
@@ -53,7 +53,7 @@ export type PerformanceOverviewMetrics = {
     nationalIncidentStatus: string;
 };
 
-export type IncidentStatus = "Watch" | "Alert" | "Respond" | "All";
+export type IncidentStatus = "Watch" | "Alert" | "Respond" | "ALL";
 
 type BaseCounts = {
     name: DiseaseNames | HazardNames;


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #?

### :memo: Implementation
- [x] Fix total cards count: when no filter is selected, only alerts with "ALL" event status are shown

### :video_camera: Screenshots/Screen capture

https://github.com/user-attachments/assets/a72a6754-d822-4849-ad33-8971c563723a



### :fire: Notes to the tester
