### PR TITLE
Changes to mapping-script notifications

### DIFF
--- a/src/data/repositories/NotificationD2Repository.ts
+++ b/src/data/repositories/NotificationD2Repository.ts
@@ -8,6 +8,7 @@ import { Future } from "../../domain/entities/generic/Future";
 import { UserGroup } from "../../domain/entities/UserGroup";
 import { OutbreakAlert } from "../../domain/entities/alert/OutbreakAlert";
 import i18n from "../../utils/i18n";
+import { verificationStatusCodeMap } from "./consts/AlertConstants";
 
 export class NotificationD2Repository implements NotificationRepository {
     constructor(private api: D2Api) {}
@@ -30,8 +31,14 @@ export class NotificationD2Repository implements NotificationRepository {
 }
 
 function buildNotificationText(outbreakKey: string, notificationData: NotificationOptions): string {
-    const { detectionDate, emergenceDate, incidentManager, notificationDate, verificationStatus } =
-        notificationData;
+    const {
+        detectionDate,
+        emergenceDate,
+        incidentManager,
+        notificationDate,
+        verificationStatus: verificationStatusCode,
+    } = notificationData;
+    const verificationStatus = verificationStatusCodeMap[verificationStatusCode] ?? "";
 
     return i18n.t(`There has been a new Outbreak detected for ${outbreakKey} in zm Zambia Ministry of Health.
 

--- a/src/data/repositories/NotificationD2Repository.ts
+++ b/src/data/repositories/NotificationD2Repository.ts
@@ -96,8 +96,8 @@ export class NotificationD2Repository implements NotificationRepository {
 }
 
 function buildNotificationText(
-    outbreakKey: string,
-    district: string,
+    outbreakName: string,
+    districtName: string,
     notificationData: NotificationOptions
 ): string {
     const {
@@ -111,7 +111,7 @@ function buildNotificationText(
     } = notificationData;
     const verificationStatus = verificationStatusCodeMap[verificationStatusCode] ?? "";
 
-    return i18n.t(`There has been a new Outbreak detected for ${outbreakKey} in ${district}.
+    return i18n.t(`There has been a new Outbreak detected for ${outbreakName} in ${districtName}.
 
 Please see the details of the outbreak below:
 

--- a/src/data/repositories/OutbreakAlertD2Repository.ts
+++ b/src/data/repositories/OutbreakAlertD2Repository.ts
@@ -91,12 +91,14 @@ export class OutbreakAlertD2Repository implements OutbreakAlertRepository {
         diseaseType: Maybe<Attribute>,
         hazardType: Maybe<Attribute>
     ): Maybe<OutbreakData> {
-        // use a full mapping (record/switch)
-        return diseaseType
-            ? { value: diseaseType.value, type: "disease" }
-            : hazardType
-            ? { value: hazardType.value, type: "hazard" }
-            : undefined;
+        switch (true) {
+            case !!diseaseType:
+                return { value: diseaseType.value, type: "disease" };
+            case !!hazardType:
+                return { value: hazardType.value, type: "hazard" };
+            default:
+                return undefined;
+        }
     }
 
     private getAlertTEAttributes(trackedEntity: D2TrackerTrackedEntity) {

--- a/src/data/repositories/consts/AlertConstants.ts
+++ b/src/data/repositories/consts/AlertConstants.ts
@@ -5,6 +5,8 @@ export const alertOutbreakCodes = {
     suspectedDisease: "RTSL_ZEB_TEA_DISEASE",
     verificationStatus: "RTSL_ZEB_TEA_VERIFICATION_STATUS",
     incidentManager: "RTSL_ZEB_TEA_ ALERT_IM_NAME",
+    outbreakId: "RTSL_ZEB_TEA_ OutBreak_ID",
+    emsId: "RTSL_ZEB_TEA_EMS_ID",
 } as const;
 
 export const verificationStatusCodeMap: Record<string, AlertVerificationStatus> = {

--- a/src/data/repositories/consts/AlertConstants.ts
+++ b/src/data/repositories/consts/AlertConstants.ts
@@ -1,6 +1,14 @@
+import { AlertVerificationStatus } from "../../../domain/entities/alert/Alert";
+
 export const alertOutbreakCodes = {
     hazardType: "RTSL_ZEB_TEA_EVENT_TYPE",
     suspectedDisease: "RTSL_ZEB_TEA_DISEASE",
     verificationStatus: "RTSL_ZEB_TEA_VERIFICATION_STATUS",
     incidentManager: "RTSL_ZEB_TEA_ ALERT_IM_NAME",
+} as const;
+
+export const verificationStatusCodeMap: Record<string, AlertVerificationStatus> = {
+    RTSL_ZEB_AL_OS_VERIFICATION_VERIFIED: "Verified ",
+    RTSL_ZEB_AL_OS_VERIFICATION_PENDING_VERIFICATION: "Pending Verification",
+    RTSL_ZEB_AL_OS_VERIFICATION_NOT_AN_EVENT: "Not an event",
 } as const;

--- a/src/data/repositories/utils/AlertOutbreakMapper.ts
+++ b/src/data/repositories/utils/AlertOutbreakMapper.ts
@@ -22,6 +22,8 @@ export function mapTrackedEntityAttributesToNotificationOptions(
     const emergenceDate = getValueFromMap("emergedDate", trackedEntity);
     const detectionDate = getValueFromMap("detectedDate", trackedEntity);
     const notificationDate = getValueFromMap("notifiedDate", trackedEntity);
+    const emsId = getAlertValueFromMap("emsId", trackedEntity);
+    const outbreakId = getAlertValueFromMap("outbreakId", trackedEntity);
 
     return {
         detectionDate: detectionDate,
@@ -29,6 +31,8 @@ export function mapTrackedEntityAttributesToNotificationOptions(
         incidentManager: incidentManager,
         notificationDate: notificationDate,
         verificationStatus: verificationStatus,
+        emsId: emsId,
+        outbreakId: outbreakId,
     };
 }
 

--- a/src/data/repositories/utils/AlertOutbreakMapper.ts
+++ b/src/data/repositories/utils/AlertOutbreakMapper.ts
@@ -9,11 +9,15 @@ import {
     RTSL_ZEBRA_ALERTS_EVENT_TYPE_TEA_ID,
 } from "../consts/DiseaseOutbreakConstants";
 import { DataSource } from "../../../domain/entities/disease-outbreak-event/DiseaseOutbreakEvent";
+import { AlertVerificationStatus } from "../../../domain/entities/alert/Alert";
 
 export function mapTrackedEntityAttributesToNotificationOptions(
     trackedEntity: D2TrackerTrackedEntity
 ): NotificationOptions {
-    const verificationStatus = getAlertValueFromMap("verificationStatus", trackedEntity);
+    const verificationStatus = getAlertValueFromMap(
+        "verificationStatus",
+        trackedEntity
+    ) as AlertVerificationStatus;
     const incidentManager = getAlertValueFromMap("incidentManager", trackedEntity);
     const emergenceDate = getValueFromMap("emergedDate", trackedEntity);
     const detectionDate = getValueFromMap("detectedDate", trackedEntity);

--- a/src/domain/entities/alert/Alert.ts
+++ b/src/domain/entities/alert/Alert.ts
@@ -8,3 +8,11 @@ export enum VerificationStatus {
     RTSL_ZEB_AL_OS_VERIFICATION_PENDING_VERIFICATION = "RTSL_ZEB_AL_OS_VERIFICATION_PENDING_VERIFICATION",
     RTSL_ZEB_AL_OS_VERIFICATION_NOT_AN_EVENT = "RTSL_ZEB_AL_OS_VERIFICATION_NOT_AN_EVENT",
 }
+
+export const alertVerificationStates = [
+    "Verified ",
+    "Pending Verification",
+    "Not an event",
+] as const;
+
+export type AlertVerificationStatus = (typeof alertVerificationStates)[number];

--- a/src/domain/entities/alert/OutbreakAlert.ts
+++ b/src/domain/entities/alert/OutbreakAlert.ts
@@ -16,3 +16,8 @@ export type OutbreakAlert = {
     outbreakData: OutbreakData;
     notificationOptions: NotificationOptions;
 };
+
+export type NotifiedAlert = {
+    district: string;
+    outbreak: string;
+};

--- a/src/domain/repositories/NotificationRepository.ts
+++ b/src/domain/repositories/NotificationRepository.ts
@@ -1,4 +1,5 @@
 import { FutureData } from "../../data/api-futures";
+import { AlertVerificationStatus } from "../entities/alert/Alert";
 import { OutbreakAlert } from "../entities/alert/OutbreakAlert";
 import { UserGroup } from "../entities/UserGroup";
 
@@ -15,5 +16,5 @@ export type NotificationOptions = {
     emergenceDate: string;
     incidentManager: string;
     notificationDate: string;
-    verificationStatus: string;
+    verificationStatus: AlertVerificationStatus;
 };

--- a/src/domain/repositories/NotificationRepository.ts
+++ b/src/domain/repositories/NotificationRepository.ts
@@ -14,7 +14,9 @@ export interface NotificationRepository {
 export type NotificationOptions = {
     detectionDate: string;
     emergenceDate: string;
+    emsId: string;
     incidentManager: string;
     notificationDate: string;
+    outbreakId: string;
     verificationStatus: AlertVerificationStatus;
 };


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/8696yv15k

### :memo: Implementation
- [x] Send notification to national watch staff users only when no notification has been sent for that district/outbreak
- [x] Include outbreak and EMS IDs in notification body
- [x] Indicate the exact district in notification
- [x] Use verification status and not verification status code in notification body

### :video_camera: Screenshots/Screen capture
<img width="1188" alt="Screenshot 2024-12-17 at 15 34 09" src="https://github.com/user-attachments/assets/25a88e79-7e23-41bc-8fe9-24857ca5b2f2" />
<img width="1188" alt="Screenshot 2024-12-17 at 15 34 47" src="https://github.com/user-attachments/assets/605ea38b-bd62-4edb-b4fc-d90ae488e154" />

### :fire: Notes to the tester
To test, set auth credentials in `.env` file and run
```yarn script-map-outbreak-to-alerts```

#8696yv15k