### PR TITLE
Create 717 Indicator Cards (Alerts) - Dashboard

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2024-12-23T12:10:07.048Z\n"
-"PO-Revision-Date: 2024-12-23T12:10:07.048Z\n"
+"POT-Creation-Date: 2024-12-27T13:45:20.506Z\n"
+"PO-Revision-Date: 2024-12-27T13:45:20.506Z\n"
 
 msgid "Low"
 msgstr ""
@@ -171,10 +171,13 @@ msgstr ""
 msgid "All public health events"
 msgstr ""
 
-msgid "7-1-7 performance"
+msgid "Alerts 7-1-7 performance"
 msgstr ""
 
 msgid "events"
+msgstr ""
+
+msgid "7-1-7 performance"
 msgstr ""
 
 msgid "Performance overview"

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2024-12-23T12:07:43.318Z\n"
+"POT-Creation-Date: 2024-12-27T13:45:20.506Z\n"
 "PO-Revision-Date: 2018-10-25T09:02:35.143Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -170,10 +170,13 @@ msgstr ""
 msgid "All public health events"
 msgstr ""
 
-msgid "7-1-7 performance"
+msgid "Alerts 7-1-7 performance"
 msgstr ""
 
 msgid "events"
+msgstr ""
+
+msgid "7-1-7 performance"
 msgstr ""
 
 msgid "Performance overview"

--- a/src/data/repositories/test/PerformanceOverviewTestRepository.ts
+++ b/src/data/repositories/test/PerformanceOverviewTestRepository.ts
@@ -6,9 +6,7 @@ import { PerformanceOverviewRepository } from "../../../domain/repositories/Perf
 import { FutureData } from "../../api-futures";
 
 export class PerformanceOverviewTestRepository implements PerformanceOverviewRepository {
-    getEventTracker717Performance(
-        _diseaseOutbreakEventId: Id
-    ): FutureData<PerformanceMetrics717[]> {
+    getEvent717Performance(_diseaseOutbreakEventId: Id): FutureData<PerformanceMetrics717[]> {
         return Future.success([]);
     }
     getEventTrackerOverviewMetrics(): FutureData<OverviewCard[]> {
@@ -17,7 +15,11 @@ export class PerformanceOverviewTestRepository implements PerformanceOverviewRep
     getTotalCardCounts(): FutureData<any> {
         return Future.success(0);
     }
-    getDashboard717Performance(): FutureData<any> {
+    getNational717Performance(): FutureData<any> {
+        return Future.success(0);
+    }
+
+    getAlerts717Performance(): FutureData<any> {
         return Future.success(0);
     }
 

--- a/src/domain/entities/disease-outbreak-event/PerformanceOverviewMetrics.ts
+++ b/src/domain/entities/disease-outbreak-event/PerformanceOverviewMetrics.ts
@@ -79,5 +79,5 @@ export type PerformanceMetrics717 = {
     name: string;
     type: "primary" | "secondary";
     value?: number | "Inc";
-    key: "dashboard" | "event_tracker";
+    key: "national" | "event" | "alerts";
 };

--- a/src/domain/entities/disease-outbreak-event/PerformanceOverviewMetrics.ts
+++ b/src/domain/entities/disease-outbreak-event/PerformanceOverviewMetrics.ts
@@ -74,10 +74,12 @@ type HazardCounts = BaseCounts & {
 
 export type TotalCardCounts = DiseaseCounts | HazardCounts;
 
+export type PerformanceMetrics717Key = "national" | "event" | "alerts";
+
 export type PerformanceMetrics717 = {
     id: string;
     name: string;
     type: "primary" | "secondary";
     value?: number | "Inc";
-    key: "national" | "event" | "alerts";
+    key: PerformanceMetrics717Key;
 };

--- a/src/domain/repositories/PerformanceOverviewRepository.ts
+++ b/src/domain/repositories/PerformanceOverviewRepository.ts
@@ -21,8 +21,9 @@ export interface PerformanceOverviewRepository {
         multiSelectFilters?: Record<string, string[]>,
         dateRangeFilter?: string[]
     ): FutureData<TotalCardCounts[]>;
-    getDashboard717Performance(): FutureData<PerformanceMetrics717[]>;
-    getEventTracker717Performance(diseaseOutbreakEventId: Id): FutureData<PerformanceMetrics717[]>;
+    getNational717Performance(): FutureData<PerformanceMetrics717[]>;
+    getEvent717Performance(diseaseOutbreakEventId: Id): FutureData<PerformanceMetrics717[]>;
+    getAlerts717Performance(): FutureData<PerformanceMetrics717[]>;
     getEventTrackerOverviewMetrics(
         type: string,
         casesDataSource: CasesDataSource

--- a/src/domain/usecases/Get717PerformanceUseCase.ts
+++ b/src/domain/usecases/Get717PerformanceUseCase.ts
@@ -11,15 +11,17 @@ export class Get717PerformanceUseCase {
     ) {}
 
     public execute(
-        type: "dashboard" | "event_tracker",
+        type: "national" | "event" | "alerts",
         diseaseOutbreakEventId: Id | undefined
     ): FutureData<PerformanceMetrics717[]> {
-        if (type === "event_tracker" && diseaseOutbreakEventId) {
-            return this.options.performanceOverviewRepository.getEventTracker717Performance(
+        if (type === "event" && diseaseOutbreakEventId) {
+            return this.options.performanceOverviewRepository.getEvent717Performance(
                 diseaseOutbreakEventId
             );
-        } else if (type === "dashboard") {
-            return this.options.performanceOverviewRepository.getDashboard717Performance();
+        } else if (type === "national") {
+            return this.options.performanceOverviewRepository.getNational717Performance();
+        } else if (type === "alerts") {
+            return this.options.performanceOverviewRepository.getAlerts717Performance();
         } else throw new Error(`Unknown 717 type: ${type} `);
     }
 }

--- a/src/domain/usecases/Get717PerformanceUseCase.ts
+++ b/src/domain/usecases/Get717PerformanceUseCase.ts
@@ -1,5 +1,8 @@
 import { FutureData } from "../../data/api-futures";
-import { PerformanceMetrics717 } from "../entities/disease-outbreak-event/PerformanceOverviewMetrics";
+import {
+    PerformanceMetrics717,
+    PerformanceMetrics717Key,
+} from "../entities/disease-outbreak-event/PerformanceOverviewMetrics";
 import { Id } from "../entities/Ref";
 import { PerformanceOverviewRepository } from "../repositories/PerformanceOverviewRepository";
 
@@ -11,7 +14,7 @@ export class Get717PerformanceUseCase {
     ) {}
 
     public execute(
-        type: "national" | "event" | "alerts",
+        type: PerformanceMetrics717Key,
         diseaseOutbreakEventId: Id | undefined
     ): FutureData<PerformanceMetrics717[]> {
         if (type === "event" && diseaseOutbreakEventId) {

--- a/src/webapp/pages/dashboard/DashboardPage.tsx
+++ b/src/webapp/pages/dashboard/DashboardPage.tsx
@@ -40,7 +40,14 @@ export const DashboardPage: React.FC = React.memo(() => {
         isLoading: performanceOverviewLoading,
     } = usePerformanceOverview();
 
-    const { performanceMetrics717, isLoading: _717CardsLoading } = use717Performance("dashboard");
+    const {
+        performanceMetrics717: nationalPerformanceMetrics717,
+        isLoading: national717CardsLoading,
+    } = use717Performance("national");
+
+    const { performanceMetrics717: alertsPerformanceMetrics717, isLoading: alerts717CardsLoading } =
+        use717Performance("alerts");
+
     const { cardCounts, isLoading: cardCountsLoading } = useCardCounts(
         singleSelectFilters,
         multiSelectFilters,
@@ -55,7 +62,7 @@ export const DashboardPage: React.FC = React.memo(() => {
         resetCurrentEventTrackerId();
     }, [resetCurrentEventTrackerId]);
 
-    return performanceOverviewLoading || _717CardsLoading ? (
+    return performanceOverviewLoading || national717CardsLoading || alerts717CardsLoading ? (
         <Loader />
     ) : (
         <Layout
@@ -125,9 +132,26 @@ export const DashboardPage: React.FC = React.memo(() => {
                     dateRangeFilter={dateRangeFilter.value}
                 />
             </Section>
+            <Section title={i18n.t("Alerts 7-1-7 performance")}>
+                <GridWrapper>
+                    {alertsPerformanceMetrics717.map(
+                        (perfMetric717: PerformanceMetric717, index: number) => (
+                            <StatsCard
+                                key={index}
+                                stat={`${perfMetric717.primaryValue}`}
+                                title={perfMetric717.title}
+                                pretitle={`${perfMetric717.secondaryValue} ${i18n.t("events")}`}
+                                color={perfMetric717.color}
+                                fillParent
+                                isPercentage
+                            />
+                        )
+                    )}
+                </GridWrapper>
+            </Section>
             <Section title={i18n.t("7-1-7 performance")}>
                 <GridWrapper>
-                    {performanceMetrics717.map(
+                    {nationalPerformanceMetrics717.map(
                         (perfMetric717: PerformanceMetric717, index: number) => (
                             <StatsCard
                                 key={index}

--- a/src/webapp/pages/dashboard/use717Performance.ts
+++ b/src/webapp/pages/dashboard/use717Performance.ts
@@ -25,7 +25,7 @@ export type PerformanceMetric717State = {
 export type Order = { name: string; direction: "asc" | "desc" };
 
 export function use717Performance(
-    type: "dashboard" | "event_tracker",
+    type: "national" | "event" | "alerts",
     diseaseOutbreakEventId?: Id
 ): PerformanceMetric717State {
     const { compositionRoot } = useAppContext();
@@ -34,8 +34,8 @@ export function use717Performance(
     const [isLoading, setIsLoading] = useState(false);
 
     const getColor = useCallback(
-        (key: string, value: number | "Inc", type: "dashboard" | "event_tracker"): CardColors => {
-            if (type === "dashboard") {
+        (key: string, value: number | "Inc", type: "national" | "event" | "alerts"): CardColors => {
+            if (type === "national") {
                 switch (key) {
                     case "allTargets":
                         return "grey";

--- a/src/webapp/pages/dashboard/use717Performance.ts
+++ b/src/webapp/pages/dashboard/use717Performance.ts
@@ -2,7 +2,10 @@ import { useCallback, useEffect, useState } from "react";
 import { useAppContext } from "../../contexts/app-context";
 import _ from "../../../domain/entities/generic/Collection";
 import { StatsCardProps } from "../../components/stats-card/StatsCard";
-import { PerformanceMetrics717 } from "../../../domain/entities/disease-outbreak-event/PerformanceOverviewMetrics";
+import {
+    PerformanceMetrics717,
+    PerformanceMetrics717Key,
+} from "../../../domain/entities/disease-outbreak-event/PerformanceOverviewMetrics";
 import { Id } from "../../../domain/entities/Ref";
 
 type CardColors = StatsCardProps["color"];
@@ -25,7 +28,7 @@ export type PerformanceMetric717State = {
 export type Order = { name: string; direction: "asc" | "desc" };
 
 export function use717Performance(
-    type: "national" | "event" | "alerts",
+    type: PerformanceMetrics717Key,
     diseaseOutbreakEventId?: Id
 ): PerformanceMetric717State {
     const { compositionRoot } = useAppContext();
@@ -34,7 +37,7 @@ export function use717Performance(
     const [isLoading, setIsLoading] = useState(false);
 
     const getColor = useCallback(
-        (key: string, value: number | "Inc", type: "national" | "event" | "alerts"): CardColors => {
+        (key: string, value: number | "Inc", type: PerformanceMetrics717Key): CardColors => {
             if (type === "national") {
                 switch (key) {
                     case "allTargets":

--- a/src/webapp/pages/event-tracker/EventTrackerPage.tsx
+++ b/src/webapp/pages/event-tracker/EventTrackerPage.tsx
@@ -74,10 +74,7 @@ export const EventTrackerPage: React.FC = React.memo(() => {
         });
     }, [goTo]);
 
-    const { performanceMetrics717, isLoading: _717CardsLoading } = use717Performance(
-        "event_tracker",
-        id
-    );
+    const { performanceMetrics717, isLoading: _717CardsLoading } = use717Performance("event", id);
 
     useEffect(() => {
         if (eventTrackerDetails) {


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #8695yhtd8 [Create 717 Indicator Cards (Alerts) - Dashboard](https://app.clickup.com/t/8695yhtd8)

### :warning: Metadata changes:
- [old Datastore key 717-performance-program-indicators](https://metadata.eyeseetea.com/rsl-zebra240/dhis-web-datastore/index.html#/edit/zebra/717-performance-program-indicators) separated into 3 new datastore keys:alerts-717-performance-program-indicators, event-tracker-717-performance-program-indicators and national-717-performance-program-indicators. Also changed keys in the data `dashboard` --> `national`, `event_tracker` --> `event` and added new key `alert`
- TODO: when this PR is merged delete keys `dashboard` and `event_tracker` from datastore and delete old key https://metadata.eyeseetea.com/rsl-zebra240/dhis-web-datastore/index.html#/edit/zebra/717-performance-program-indicators from datstore

### :memo: Implementation
- Add 717 performance alerts cards in dashboards

### :video_camera: Screenshots/Screen capture

![image](https://github.com/user-attachments/assets/87934c12-cfdc-4d07-b660-cce5644974a1)


### :fire: Notes to the tester
