### PR TITLE
fix: improve handling when mandatory fields are missing

### DIFF
--- a/src/data/repositories/utils/DiseaseOutbreakMapper.ts
+++ b/src/data/repositories/utils/DiseaseOutbreakMapper.ts
@@ -36,7 +36,7 @@ type D2TrackedEntityAttribute = {
 
 export function mapTrackedEntityAttributesToDiseaseOutbreak(
     trackedEntity: D2TrackerTrackedEntity
-): DiseaseOutbreakEventBaseAttrs {
+): DiseaseOutbreakEventBaseAttrs | undefined {
     if (!trackedEntity.trackedEntity) throw new Error("Tracked entity not found");
 
     const fromMap = (key: keyof typeof diseaseOutbreakCodes) => getValueFromMap(key, trackedEntity);
@@ -47,7 +47,7 @@ export function mapTrackedEntityAttributesToDiseaseOutbreak(
         casesDataSourceMap[fromMap("casesDataSource")] ??
         CasesDataSource.RTSL_ZEB_OS_CASE_DATA_SOURCE_eIDSR;
 
-    if (!dataSource || !incidentStatus) throw new Error("Data source or incident status not valid");
+    if (!dataSource || !incidentStatus) return;
 
     const diseaseOutbreak: DiseaseOutbreakEventBaseAttrs = {
         id: trackedEntity.trackedEntity,

--- a/src/domain/usecases/GetAllNationalPerformanceOverviewMetricsUseCase.ts
+++ b/src/domain/usecases/GetAllNationalPerformanceOverviewMetricsUseCase.ts
@@ -15,8 +15,12 @@ export class GetAllNationalPerformanceOverviewMetricsUseCase {
         return this.options.diseaseOutbreakEventRepository
             .getAll()
             .flatMap(diseaseOutbreakEvents => {
+                //Do not process events without Suspected disease or Hazard Type set as they are mandatory.
+                const filteredEvents = diseaseOutbreakEvents.filter(
+                    event => event.hazardType || event.suspectedDiseaseCode
+                );
                 return this.options.performanceOverviewRepository.getNationalPerformanceOverviewMetrics(
-                    diseaseOutbreakEvents
+                    filteredEvents
                 );
             });
     }


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #8697rgbvq, https://app.clickup.com/t/8697rgbvq

### :memo: Implementation
1. Even if fields like suspected disease/hazard type, incident status, data source are missing handle the error gracefully.

### :video_camera: Screenshots/Screen capture

### :fire: Notes to the tester
