### PR TITLE
[feature]: Add total event count in 717 cards

### DIFF
--- a/src/data/repositories/PerformanceOverviewD2Repository.ts
+++ b/src/data/repositories/PerformanceOverviewD2Repository.ts
@@ -67,7 +67,8 @@ const EVENT_TRACKER_PERFORMANCE_717_PROGRAM_INDICATORS_DATASTORE_KEY =
     "event-tracker-717-performance-program-indicators";
 const ALERTS_PERFORMANCE_717_PROGRAM_INDICATORS_DATASTORE_KEY =
     "alerts-717-performance-program-indicators";
-const TOTALS_PERFORMANCE_717_PROGRAM_INDICATORS_DATASTORE_KEY = "total-717-performance-indicators";
+const TOTALS_PERFORMANCE_717_PROGRAM_INDICATORS_DATASTORE_KEY =
+    "total-717-performance-program-indicators";
 const PERFORMANCE_OVERVIEW_DIMENSIONS_DATASTORE_KEY = "performance-overview-dimensions";
 const ALERTS_PERFORMANCE_OVERVIEW_DIMENSIONS_DATASTORE_KEY =
     "alerts-performance-overview-dimensions";

--- a/src/domain/entities/disease-outbreak-event/PerformanceOverviewMetrics.ts
+++ b/src/domain/entities/disease-outbreak-event/PerformanceOverviewMetrics.ts
@@ -85,4 +85,12 @@ export type PerformanceMetrics717 = {
     type: "primary" | "secondary";
     value?: number | "Inc";
     key: PerformanceMetrics717Key;
+    total?: number;
+};
+
+export type TotalPerformanceMetrics717 = {
+    id: string;
+    type: "total";
+    value?: number | "Inc";
+    key: PerformanceMetrics717Key;
 };

--- a/src/webapp/pages/dashboard/AlertsDashboard.tsx
+++ b/src/webapp/pages/dashboard/AlertsDashboard.tsx
@@ -22,6 +22,7 @@ import { TotalCardCounts } from "../../../domain/entities/disease-outbreak-event
 import { AlertsPerformanceOverviewMetricsTableData, Order } from "./useAlertsPerformanceOverview";
 import { Maybe } from "../../../utils/ts-utils";
 import { Option } from "../../components/utils/option";
+import { formatStatCardPreTitle } from "./NationalDashboard";
 
 export type AlertsDashboardProps = {
     selectorFiltersConfig: SelectorFiltersConfig[];
@@ -151,7 +152,7 @@ export const AlertsDashboard: React.FC<AlertsDashboardProps> = React.memo(props 
                                 key={index}
                                 stat={`${perfMetric717.primaryValue}`}
                                 title={perfMetric717.title}
-                                pretitle={`${perfMetric717.secondaryValue} ${i18n.t("events")}`}
+                                pretitle={formatStatCardPreTitle(perfMetric717)}
                                 color={perfMetric717.color}
                                 fillParent
                                 isPercentage

--- a/src/webapp/pages/dashboard/NationalDashboard.tsx
+++ b/src/webapp/pages/dashboard/NationalDashboard.tsx
@@ -58,7 +58,7 @@ export const NationalDashboard: React.FC<NationalDashboardProps> = React.memo(pr
                                 key={index}
                                 stat={`${perfMetric717.primaryValue}`}
                                 title={perfMetric717.title}
-                                pretitle={`${perfMetric717.secondaryValue} ${i18n.t("events")}`}
+                                pretitle={formatStatCardPreTitle(perfMetric717)}
                                 color={perfMetric717.color}
                                 fillParent
                                 isPercentage
@@ -91,3 +91,9 @@ const StatisticTableWrapper = styled.div`
     display: grid;
     row-gap: 16px;
 `;
+
+export function formatStatCardPreTitle(perfMetric717: PerformanceMetric717): string {
+    return `${perfMetric717.secondaryValue} ${
+        perfMetric717.totalValue ? `of ${perfMetric717.totalValue}` : ""
+    } ${i18n.t("events")}`;
+}

--- a/src/webapp/pages/dashboard/use717Performance.ts
+++ b/src/webapp/pages/dashboard/use717Performance.ts
@@ -19,6 +19,7 @@ export type PerformanceMetric717 = {
     primaryValue: number | "Inc";
     secondaryValue: number | "Inc";
     color: CardColors;
+    totalValue?: number;
 };
 export type PerformanceMetric717State = {
     performanceMetrics717: PerformanceMetric717[];
@@ -86,6 +87,7 @@ export function use717Performance(
                         primaryValue: primaryValue,
                         secondaryValue: secondaryValue,
                         color: getColor(keyframes, primaryValue, type),
+                        totalValue: _(values).first()?.total,
                     };
                 })
                 .values();


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/8698ncg72

### :memo: Implementation
- [x] Add new data store key for total 717 performance program indicators -> `total-717-performance-program-indicators`
- [x] Update alert and zebra event dashboards with total event counts

### :video_camera: Screenshots/Screen capture

https://github.com/user-attachments/assets/b07392e3-4100-4377-b917-4725b7c5344e


### :fire: Notes to the tester
This is an example config for `total-717-performance-program-indicators`:
```
[
  {
    "id": total_national_program_indicator_id,
    "key": "national",
    "type": "total"
  },
  {
    "id":  total_alerts_program_indicator_id,
    "key": "alerts",
    "type": "total"
  }
]
```
#8698ncg72