### PR TITLE
fix: hardcode default datasource as ND1

### DIFF
--- a/src/data/repositories/consts/DiseaseOutbreakConstants.ts
+++ b/src/data/repositories/consts/DiseaseOutbreakConstants.ts
@@ -1,5 +1,6 @@
 import {
     CasesDataSource,
+    DataSource,
     DiseaseOutbreakEventBaseAttrs,
 } from "../../../domain/entities/disease-outbreak-event/DiseaseOutbreakEvent";
 import _c from "../../../domain/entities/generic/Collection";
@@ -27,6 +28,11 @@ export const RTSL_ZEBRA_ALERTS_PHEOC_STATUS_ID = "KeUbzfFQYCX";
 export const casesDataSourceMap: Record<string, CasesDataSource> = {
     RTSL_ZEB_OS_CASE_DATA_SOURCE_eIDSR: CasesDataSource.RTSL_ZEB_OS_CASE_DATA_SOURCE_eIDSR,
     RTSL_ZEB_OS_CASE_DATA_SOURCE_USER_DEF: CasesDataSource.RTSL_ZEB_OS_CASE_DATA_SOURCE_USER_DEF,
+};
+
+export const dataSourceMap: Record<string, DataSource> = {
+    ND1: DataSource.ND1,
+    ND2: DataSource.ND2,
 };
 
 export const diseaseOutbreakCodes = {
@@ -58,6 +64,7 @@ export const diseaseOutbreakCodes = {
     incidentManager: "RTSL_ZEB_TEA_ASSIGN_INCIDENT_MANAGER",
     notes: "RTSL_ZEB_TEA_NOTES",
     casesDataSource: "RTSL_ZEB_TEA_CASE_DATA_SOURCE",
+    dataSource: "RTSL_ZEB_TEA_DEFAULT_DATA_SOURCE",
 } as const;
 
 export type DiseaseOutbreakCode = GetValue<typeof diseaseOutbreakCodes>;
@@ -139,6 +146,7 @@ export function getValueFromDiseaseOutbreak(
         RTSL_ZEB_TEA_ASSIGN_INCIDENT_MANAGER: diseaseOutbreak.incidentManagerName,
         RTSL_ZEB_TEA_NOTES: diseaseOutbreak.notes ?? "",
         RTSL_ZEB_TEA_CASE_DATA_SOURCE: diseaseOutbreak.casesDataSource,
+        RTSL_ZEB_TEA_DEFAULT_DATA_SOURCE: diseaseOutbreak.dataSource,
     };
 }
 

--- a/src/data/repositories/test/DiseaseOutbreakEventTestRepository.ts
+++ b/src/data/repositories/test/DiseaseOutbreakEventTestRepository.ts
@@ -1,6 +1,7 @@
 import { OutbreakData } from "../../../domain/entities/alert/OutbreakAlert";
 import {
     CasesDataSource,
+    DataSource,
     DiseaseOutbreakEvent,
     DiseaseOutbreakEventBaseAttrs,
 } from "../../../domain/entities/disease-outbreak-event/DiseaseOutbreakEvent";
@@ -42,6 +43,7 @@ export class DiseaseOutbreakEventTestRepository implements DiseaseOutbreakEventR
             incidentManagerName: "incidentManager",
             notes: undefined,
             casesDataSource: CasesDataSource.RTSL_ZEB_OS_CASE_DATA_SOURCE_eIDSR,
+            dataSource: DataSource.ND1,
         });
     }
     getAll(): FutureData<DiseaseOutbreakEventBaseAttrs[]> {
@@ -74,6 +76,7 @@ export class DiseaseOutbreakEventTestRepository implements DiseaseOutbreakEventR
                 incidentManagerName: "incidentManager",
                 notes: undefined,
                 casesDataSource: CasesDataSource.RTSL_ZEB_OS_CASE_DATA_SOURCE_eIDSR,
+                dataSource: DataSource.ND1,
             },
             {
                 id: "2",
@@ -103,6 +106,7 @@ export class DiseaseOutbreakEventTestRepository implements DiseaseOutbreakEventR
                 incidentManagerName: "incidentManager",
                 notes: undefined,
                 casesDataSource: CasesDataSource.RTSL_ZEB_OS_CASE_DATA_SOURCE_eIDSR,
+                dataSource: DataSource.ND1,
             },
         ]);
     }
@@ -136,6 +140,7 @@ export class DiseaseOutbreakEventTestRepository implements DiseaseOutbreakEventR
                 notes: undefined,
                 status: "ACTIVE",
                 casesDataSource: CasesDataSource.RTSL_ZEB_OS_CASE_DATA_SOURCE_eIDSR,
+                dataSource: DataSource.ND1,
             },
             {
                 id: "2",
@@ -165,6 +170,7 @@ export class DiseaseOutbreakEventTestRepository implements DiseaseOutbreakEventR
                 notes: undefined,
                 status: "COMPLETED",
                 casesDataSource: CasesDataSource.RTSL_ZEB_OS_CASE_DATA_SOURCE_eIDSR,
+                dataSource: DataSource.ND1,
             },
         ]);
     }

--- a/src/data/repositories/utils/DiseaseOutbreakMapper.ts
+++ b/src/data/repositories/utils/DiseaseOutbreakMapper.ts
@@ -1,5 +1,6 @@
 import {
     CasesDataSource,
+    DataSource,
     DiseaseOutbreakEventBaseAttrs,
 } from "../../../domain/entities/disease-outbreak-event/DiseaseOutbreakEvent";
 import { D2TrackerTrackedEntity, Attribute } from "@eyeseetea/d2-api/api/trackerTrackedEntities";
@@ -13,6 +14,7 @@ import {
     RTSL_ZEBRA_PROGRAM_ID,
     RTSL_ZEBRA_TRACKED_ENTITY_TYPE_ID,
     casesDataSourceMap,
+    dataSourceMap,
 } from "../consts/DiseaseOutbreakConstants";
 import { SelectedPick } from "@eyeseetea/d2-api/api";
 import { D2TrackedEntityAttributeSchema } from "../../../types/d2-api";
@@ -40,6 +42,8 @@ export function mapTrackedEntityAttributesToDiseaseOutbreak(
     const casesDataSource =
         casesDataSourceMap[fromMap("casesDataSource")] ??
         CasesDataSource.RTSL_ZEB_OS_CASE_DATA_SOURCE_eIDSR;
+
+    const dataSource = dataSourceMap[fromMap("dataSource")] ?? DataSource.ND1;
 
     const diseaseOutbreak: DiseaseOutbreakEventBaseAttrs = {
         id: trackedEntity.trackedEntity,
@@ -92,6 +96,7 @@ export function mapTrackedEntityAttributesToDiseaseOutbreak(
         },
         notes: fromMap("notes"),
         casesDataSource: casesDataSource,
+        dataSource: dataSource,
     };
 
     return diseaseOutbreak;

--- a/src/domain/entities/disease-outbreak-event/DiseaseOutbreakEvent.ts
+++ b/src/domain/entities/disease-outbreak-event/DiseaseOutbreakEvent.ts
@@ -72,6 +72,7 @@ export type DiseaseOutbreakEventBaseAttrs = NamedRef & {
     incidentManagerName: string;
     notes: Maybe<string>;
     casesDataSource: CasesDataSource;
+    dataSource: DataSource;
 };
 
 export type DiseaseOutbreakEventAttrs = DiseaseOutbreakEventBaseAttrs & {

--- a/src/webapp/pages/event-tracker/EventTrackerPage.tsx
+++ b/src/webapp/pages/event-tracker/EventTrackerPage.tsx
@@ -74,10 +74,9 @@ export const EventTrackerPage: React.FC = React.memo(() => {
         overviewCards,
         isLoading: areOverviewCardsLoading,
         dataSourceFilter: overviewDataSourceFilter,
-    } = useOverviewCards(isCasesDataUserDefined);
-    const { dateRangeFilter, dataSourceFilter: mapDataSourceFilter } =
-        useMapFilters(isCasesDataUserDefined);
-    const chartsDataSourceFilter = useDataSourceFilter(isCasesDataUserDefined);
+    } = useOverviewCards();
+    const { dateRangeFilter, dataSourceFilter: mapDataSourceFilter } = useMapFilters();
+    const chartsDataSourceFilter = useDataSourceFilter();
 
     const goToRiskSummaryForm = useCallback(() => {
         goTo(RouteName.CREATE_FORM, {

--- a/src/webapp/pages/event-tracker/useDataSourceFilter.ts
+++ b/src/webapp/pages/event-tracker/useDataSourceFilter.ts
@@ -1,8 +1,12 @@
 import { Maybe } from "../../../utils/ts-utils";
 import { Option } from "../../components/utils/option";
-import { DataSource } from "../../../domain/entities/disease-outbreak-event/DiseaseOutbreakEvent";
+import {
+    CasesDataSource,
+    DataSource,
+} from "../../../domain/entities/disease-outbreak-event/DiseaseOutbreakEvent";
 import { useMemo, useState } from "react";
 import { useAppContext } from "../../contexts/app-context";
+import { useCurrentEventTracker } from "../../contexts/current-event-tracker-context";
 
 export type DataSourceFiltersState = {
     onChange: (value: string) => void;
@@ -11,9 +15,17 @@ export type DataSourceFiltersState = {
     dataSource: Maybe<DataSource>;
 };
 
-export function useDataSourceFilter(isCasesDataUserDefined: boolean) {
+export function useDataSourceFilter() {
     const { configurations } = useAppContext();
-    const [dataSourceFilter, setDataSourceFilter] = useState(DataSource.ND1 as string);
+    const { getCurrentEventTracker } = useCurrentEventTracker();
+    const currentEventTracker = getCurrentEventTracker();
+
+    const isCasesDataUserDefined =
+        currentEventTracker?.casesDataSource ===
+        CasesDataSource.RTSL_ZEB_OS_CASE_DATA_SOURCE_USER_DEF;
+
+    const defaultDataSource = (currentEventTracker?.dataSource || DataSource.ND1) as string;
+    const [dataSourceFilter, setDataSourceFilter] = useState(defaultDataSource);
 
     const dataSourceOptions = useMemo(
         () =>

--- a/src/webapp/pages/event-tracker/useMapFilters.ts
+++ b/src/webapp/pages/event-tracker/useMapFilters.ts
@@ -10,9 +10,9 @@ export type MapFiltersState = {
     dataSourceFilter: DataSourceFiltersState;
 };
 
-export function useMapFilters(isCasesDataUserDefined: boolean): MapFiltersState {
+export function useMapFilters(): MapFiltersState {
     const [selectedRangeDateFilter, setSelectedRangeDateFilter] = useState<string[]>([]);
-    const dataSourceFilter = useDataSourceFilter(isCasesDataUserDefined);
+    const dataSourceFilter = useDataSourceFilter();
 
     return {
         dateRangeFilter: {

--- a/src/webapp/pages/event-tracker/useOverviewCards.ts
+++ b/src/webapp/pages/event-tracker/useOverviewCards.ts
@@ -4,13 +4,13 @@ import { useCurrentEventTracker } from "../../contexts/current-event-tracker-con
 import { OverviewCard } from "../../../domain/entities/PerformanceOverview";
 import { useDataSourceFilter } from "./useDataSourceFilter";
 
-export function useOverviewCards(isCasesDataUserDefined: boolean) {
+export function useOverviewCards() {
     const { compositionRoot } = useAppContext();
     const [overviewCards, setOverviewCards] = useState<OverviewCard[]>();
     const [isLoading, setIsLoading] = useState<boolean>(false);
     const { getCurrentEventTracker } = useCurrentEventTracker();
     const currentEventTracker = getCurrentEventTracker();
-    const dataSourceFilter = useDataSourceFilter(isCasesDataUserDefined);
+    const dataSourceFilter = useDataSourceFilter();
 
     useEffect(() => {
         const type = currentEventTracker?.suspectedDiseaseCode;

--- a/src/webapp/pages/form-page/disease-outbreak-event/mapFormStateToDiseaseOutbreakEvent.ts
+++ b/src/webapp/pages/form-page/disease-outbreak-event/mapFormStateToDiseaseOutbreakEvent.ts
@@ -2,6 +2,7 @@ import { DiseaseOutbreakEventFormData } from "../../../../domain/entities/Config
 import {
     DiseaseOutbreakEvent,
     CasesDataSource,
+    DataSource,
     DiseaseOutbreakEventBaseAttrs,
 } from "../../../../domain/entities/disease-outbreak-event/DiseaseOutbreakEvent";
 import { Maybe } from "../../../../utils/ts-utils";
@@ -176,6 +177,7 @@ function getDiseaseOutbreakEventFromDiseaseOutbreakForm(
         created: diseaseOutbreakEvent?.created,
         lastUpdated: diseaseOutbreakEvent?.lastUpdated,
         createdByName: diseaseOutbreakEvent?.createdByName || currentUserName,
+        dataSource: diseaseOutbreakEvent?.dataSource || DataSource.ND1,
         ...diseaseOutbreakEventEditableData,
     };
     const newDiseaseOutbreakEvent = new DiseaseOutbreakEvent({


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #8698qzke0 [Make Changes to Create Event Form](https://app.clickup.com/t/8698qzke0)

### :memo: Implementation
- include `default data source (ND1/ND2)` in entity
- hard code default value of ND1 upon saving

TODO:
- fetch default value from dataStore
- handling in saving to not overwrite saved dataSource when editing 

### :video_camera: Screenshots/Screen capture

### :fire: Notes to the tester
