### PR TITLE
fix: Filter only active when mapping disease id to alert

### DIFF
--- a/src/data/repositories/AlertD2Repository.ts
+++ b/src/data/repositories/AlertD2Repository.ts
@@ -14,7 +14,11 @@ import { D2TrackerTrackedEntity } from "@eyeseetea/d2-api/api/trackerTrackedEnti
 import { Maybe } from "../../utils/ts-utils";
 import { Alert, PHEOCStatus, VerificationStatus } from "../../domain/entities/alert/Alert";
 import { OutbreakData } from "../../domain/entities/alert/OutbreakAlert";
-import { getAllTrackedEntitiesAsync } from "./utils/getAllTrackedEntities";
+import {
+    getAllTrackedEntitiesAsync,
+    ProgramStatus,
+    programStatusOptions,
+} from "./utils/getAllTrackedEntities";
 import { getAlertValueFromMap, outbreakTEAMapping } from "./utils/AlertOutbreakMapper";
 import { IncidentStatus } from "../../domain/entities/disease-outbreak-event/PerformanceOverviewMetrics";
 
@@ -39,6 +43,7 @@ export class AlertD2Repository implements AlertRepository {
             orgUnit: RTSL_ZEBRA_ORG_UNIT_ID,
             ouMode: "DESCENDANTS",
             filter: outbreakData,
+            programStatus: programStatusOptions.ACTIVE,
         }).flatMap(alertTrackedEntities => {
             const alertsToPost = this.getRespondAlertsToPost(alertTrackedEntities, eventId);
             const activeVerifiedAlerts = alertsToPost.map<Alert>(trackedEntity => {
@@ -320,8 +325,9 @@ export class AlertD2Repository implements AlertRepository {
         orgUnit: Id;
         ouMode: "SELECTED" | "DESCENDANTS";
         filter: OutbreakData;
+        programStatus?: ProgramStatus;
     }): FutureData<D2TrackerTrackedEntity[]> {
-        const { program, orgUnit, ouMode, filter } = options;
+        const { program, orgUnit, ouMode, filter, programStatus } = options;
 
         return Future.fromPromise(
             getAllTrackedEntitiesAsync(this.api, {
@@ -332,6 +338,7 @@ export class AlertD2Repository implements AlertRepository {
                     id: this.getOutbreakFilterId(filter),
                     value: filter.value,
                 },
+                programStatus: programStatus,
             })
         );
     }

--- a/src/data/repositories/DiseaseOutbreakEventD2Repository.ts
+++ b/src/data/repositories/DiseaseOutbreakEventD2Repository.ts
@@ -87,7 +87,7 @@ export class DiseaseOutbreakEventD2Repository implements DiseaseOutbreakEventRep
                 programId: RTSL_ZEBRA_PROGRAM_ID,
                 orgUnitId: RTSL_ZEBRA_ORG_UNIT_ID,
                 filter: {
-                    id: RTSL_ZEBRA_DISEASE_TEA_ID,
+                    id: RTSL_ZEB_TEA_SUSPECTED_DISEASE_ID,
                     value: filter.value,
                 },
             })
@@ -211,23 +211,13 @@ export class DiseaseOutbreakEventD2Repository implements DiseaseOutbreakEventRep
     }
 
     getActiveByDisease(disease: Code): FutureData<Maybe<DiseaseOutbreakEventBaseAttrs>> {
-        return apiToFuture(
-            this.api.tracker.trackedEntities.get({
-                program: RTSL_ZEBRA_PROGRAM_ID,
-                orgUnit: RTSL_ZEBRA_ORG_UNIT_ID,
-                fields: { attributes: true, trackedEntity: true, updatedAt: true },
-                filter: `${RTSL_ZEB_TEA_SUSPECTED_DISEASE_ID}:eq:${disease}`,
-            })
-        )
-            .flatMap(response => assertOrError(response.instances[0], "Tracked entity"))
-            .map(trackedEntity => {
-                if (trackedEntity.inactive) return undefined;
-
-                const outbreak = mapTrackedEntityAttributesToDiseaseOutbreak(trackedEntity);
-                if (outbreak) {
-                    return outbreak;
-                }
-            });
+        return this.getEventByDisease({ type: "disease", value: disease }).map(diseaseOutbreaks => {
+            if (diseaseOutbreaks.length === 0) return undefined;
+            const activeDiseaseOutbreaks = diseaseOutbreaks.filter(
+                outbreak => outbreak.status === "ACTIVE"
+            );
+            return activeDiseaseOutbreaks[0];
+        });
     }
 
     private markCasesDataAsCompleted(diseaseOutbreakId: Id): FutureData<void> {
@@ -370,5 +360,3 @@ export class DiseaseOutbreakEventD2Repository implements DiseaseOutbreakEventRep
 
     //TO DO : Implement delete/archive after requirement confirmation
 }
-
-const RTSL_ZEBRA_DISEASE_TEA_ID = "jLvbkuvPdZ6";

--- a/src/data/repositories/DiseaseOutbreakEventD2Repository.ts
+++ b/src/data/repositories/DiseaseOutbreakEventD2Repository.ts
@@ -24,7 +24,7 @@ import {
 } from "./utils/MetadataHelper";
 import { assertOrError } from "./utils/AssertOrError";
 import { Future } from "../../domain/entities/generic/Future";
-import { getAllTrackedEntitiesAsync } from "./utils/getAllTrackedEntities";
+import { getAllTrackedEntitiesAsync, programStatusOptions } from "./utils/getAllTrackedEntities";
 import { D2TrackerEnrollment } from "@eyeseetea/d2-api/api/trackerEnrollments";
 import { D2TrackerEvent } from "@eyeseetea/d2-api/api/trackerEvents";
 import {
@@ -68,17 +68,17 @@ export class DiseaseOutbreakEventD2Repository implements DiseaseOutbreakEventRep
             getAllTrackedEntitiesAsync(this.api, {
                 programId: RTSL_ZEBRA_PROGRAM_ID,
                 orgUnitId: RTSL_ZEBRA_ORG_UNIT_ID,
+                programStatus: programStatusOptions.ACTIVE,
             })
-        ).map(trackedEntities => {
-            const filteredOutbreaks: DiseaseOutbreakEventBaseAttrs[] = _c(
+        ).map(trackedEntities =>
+            _c(
                 trackedEntities.map(trackedEntity =>
                     mapTrackedEntityAttributesToDiseaseOutbreak(trackedEntity)
                 )
             )
                 .compact()
-                .value();
-            return filteredOutbreaks.filter(outbreak => outbreak.status === "ACTIVE");
-        });
+                .value()
+        );
     }
 
     getEventByDisease(filter: OutbreakData): FutureData<DiseaseOutbreakEventBaseAttrs[]> {
@@ -90,6 +90,7 @@ export class DiseaseOutbreakEventD2Repository implements DiseaseOutbreakEventRep
                     id: RTSL_ZEB_TEA_SUSPECTED_DISEASE_ID,
                     value: filter.value,
                 },
+                programStatus: programStatusOptions.ACTIVE,
             })
         ).map(trackedEntities => {
             return _c(trackedEntities)

--- a/src/data/repositories/utils/getAllTrackedEntities.ts
+++ b/src/data/repositories/utils/getAllTrackedEntities.ts
@@ -6,6 +6,14 @@ import {
 import { Id } from "../../../domain/entities/Ref";
 import { Maybe } from "../../../utils/ts-utils";
 
+export const programStatusOptions = {
+    ACTIVE: "ACTIVE",
+    COMPLETED: "COMPLETED",
+    CANCELLED: "CANCELLED",
+} as const;
+
+export type ProgramStatus = (typeof programStatusOptions)[keyof typeof programStatusOptions];
+
 export async function getAllTrackedEntitiesAsync(
     api: D2Api,
     options: {
@@ -13,9 +21,10 @@ export async function getAllTrackedEntitiesAsync(
         orgUnitId: Id;
         ouMode?: "SELECTED" | "DESCENDANTS";
         filter?: { id: string; value: Maybe<string> };
+        programStatus?: ProgramStatus;
     }
 ): Promise<D2TrackerTrackedEntity[]> {
-    const { programId, orgUnitId, ouMode, filter } = options;
+    const { programId, orgUnitId, ouMode, filter, programStatus } = options;
     const d2TrackerTrackedEntities: D2TrackerTrackedEntity[] = [];
 
     const pageSize = 250;
@@ -34,6 +43,7 @@ export async function getAllTrackedEntitiesAsync(
                     pageSize: pageSize,
                     fields: fields,
                     filter: filter ? `${filter.id}:eq:${filter.value}` : undefined,
+                    ...(programStatus ? { programStatus } : {}),
                 })
                 .getData();
 


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #?

### :memo: Implementation
- upon updating alert status, apply active filter when fetching active event by disease 

### :video_camera: Screenshots/Screen capture

### :fire: Notes to the tester
