### PR TITLE
Pevent bad alert mapping

### DIFF
--- a/src/data/repositories/AlertD2Repository.ts
+++ b/src/data/repositories/AlertD2Repository.ts
@@ -27,8 +27,6 @@ import { getAlertValueFromMap, outbreakTEAMapping } from "./utils/AlertOutbreakM
 import { IncidentStatus } from "../../domain/entities/disease-outbreak-event/PerformanceOverviewMetrics";
 import { assertOrError } from "./utils/AssertOrError";
 
-const ALERT_TRACKED_ENTITY_TYPE = "QH1LBzGrk5g";
-
 const incidentStatusOptionMap = new Map<IncidentStatus, string>([
     ["Alert", "PHEOC_STATUS_ALERT"],
     ["Respond", "PHEOC_STATUS_RESPOND"],

--- a/src/data/repositories/AlertD2Repository.ts
+++ b/src/data/repositories/AlertD2Repository.ts
@@ -6,7 +6,11 @@ import {
     RTSL_ZEBRA_ALERTS_PROGRAM_ID,
     RTSL_ZEBRA_ORG_UNIT_ID,
 } from "./consts/DiseaseOutbreakConstants";
-import { AlertOptions, AlertRepository } from "../../domain/repositories/AlertRepository";
+import {
+    AlertOptions,
+    AlertRepository,
+    UpdatePHEOCStatusOptions,
+} from "../../domain/repositories/AlertRepository";
 import { Id } from "../../domain/entities/Ref";
 import _ from "../../domain/entities/generic/Collection";
 import { Future } from "../../domain/entities/generic/Future";
@@ -17,6 +21,7 @@ import { OutbreakData } from "../../domain/entities/alert/OutbreakAlert";
 import { getAllTrackedEntitiesAsync } from "./utils/getAllTrackedEntities";
 import { getAlertValueFromMap, outbreakTEAMapping } from "./utils/AlertOutbreakMapper";
 import { IncidentStatus } from "../../domain/entities/disease-outbreak-event/PerformanceOverviewMetrics";
+import { assertOrError } from "./utils/AssertOrError";
 
 const ALERT_TRACKED_ENTITY_TYPE = "QH1LBzGrk5g";
 
@@ -67,34 +72,29 @@ export class AlertD2Repository implements AlertRepository {
         });
     }
 
-    updateAlertPHEOCStatus(
-        alertId: Id,
-        orgUnitName: string,
-        pheocStatus: IncidentStatus
-    ): FutureData<void> {
-        return apiToFuture(
-            this.api.models.organisationUnits.get({
-                fields: { id: true },
-                filter: { name: { eq: orgUnitName } },
-            })
-        ).flatMap(resp => {
-            if (!resp.objects[0]) {
-                return Future.error(
-                    new Error(`Error fetching organisation unit id for ${orgUnitName}`)
-                );
-            }
-            const orgUnitId = resp.objects[0].id;
+    updateAlertPHEOCStatus(options: UpdatePHEOCStatusOptions): FutureData<void> {
+        const { alertId, pheocStatus, diseaseOutbreakId } = options;
+
+        return this._getAlertTrackedEntityById(alertId, {
+            trackedEntityType: true,
+            orgUnit: true,
+        }).flatMap(alertTrackedEntity => {
             const alertsToPost: D2TrackerTrackedEntity = {
                 trackedEntity: alertId,
-                trackedEntityType: ALERT_TRACKED_ENTITY_TYPE,
-                orgUnit: orgUnitId,
+                trackedEntityType: alertTrackedEntity.trackedEntityType,
+                orgUnit: alertTrackedEntity.orgUnit,
                 attributes: [
                     {
                         attribute: RTSL_ZEBRA_ALERTS_PHEOC_STATUS_ID,
                         value: this.mapIncidentStatusToOption(pheocStatus),
                     },
+                    {
+                        attribute: RTSL_ZEBRA_ALERTS_NATIONAL_DISEASE_OUTBREAK_EVENT_ID_TEA_ID,
+                        value: diseaseOutbreakId ?? "",
+                    },
                 ],
             };
+
             return apiToFuture(
                 this.api.tracker.post(
                     { importStrategy: "UPDATE" },
@@ -128,20 +128,11 @@ export class AlertD2Repository implements AlertRepository {
     }
 
     getAlertById(alertId: Id): FutureData<Alert> {
-        return apiToFuture(
-            this.api.tracker.trackedEntities.get({
-                trackedEntity: alertId,
-                program: RTSL_ZEBRA_ALERTS_PROGRAM_ID,
-                enrollmentEnrolledBefore: new Date().toISOString(),
-                fields: { orgUnit: true, attributes: true, enrollments: true },
-            })
-        ).flatMap(trackedEntityResponse => {
-            const alertTrackedEntity = trackedEntityResponse.instances[0];
-
-            if (!alertTrackedEntity) {
-                return Future.error(new Error(`Error fetching alert with id ${alertId}`));
-            }
-
+        return this._getAlertTrackedEntityById(alertId, {
+            orgUnit: true,
+            attributes: true,
+            enrollments: true,
+        }).flatMap(alertTrackedEntity => {
             const enrollment =
                 alertTrackedEntity.enrollments && alertTrackedEntity.enrollments[0]
                     ? alertTrackedEntity.enrollments[0]
@@ -163,62 +154,20 @@ export class AlertD2Repository implements AlertRepository {
         });
     }
 
-    updateMappedDiseaseOutbreakEventIdByPHEOCStatus(
-        alertId: Id,
-        pheocStatus: IncidentStatus,
-        diseaseOutbreakId?: Id
-    ): FutureData<void> {
+    private _getAlertTrackedEntityById(
+        id: Id,
+        fields?: AlertTrackerEntityFields
+    ): FutureData<D2TrackerTrackedEntity> {
         return apiToFuture(
             this.api.tracker.trackedEntities.get({
-                trackedEntity: alertId,
+                trackedEntity: id,
                 program: RTSL_ZEBRA_ALERTS_PROGRAM_ID,
                 enrollmentEnrolledBefore: new Date().toISOString(),
-                fields: { trackedEntityType: true, orgUnit: true },
+                fields: fields || alertTrackerEntityFields,
             })
-        ).flatMap(alertTrackedEntityResponse => {
-            const alertTrackedEntity = alertTrackedEntityResponse.instances[0];
-            if (!alertTrackedEntity) {
-                return Future.error(new Error(`Error fetching alert with id ${alertId}`));
-            }
-
-            if (pheocStatus === "Respond" && !diseaseOutbreakId) {
-                return Future.error(
-                    new Error(
-                        `Error while updating PHEOC status to Respond in alert with id ${alertId}`
-                    )
-                );
-            }
-
-            const updatedMappedDiseaseOutbreakEventId =
-                pheocStatus === "Respond" && diseaseOutbreakId ? diseaseOutbreakId : "";
-
-            const updatedAlert: D2TrackerTrackedEntity = {
-                trackedEntity: alertId,
-                trackedEntityType: alertTrackedEntity.trackedEntityType,
-                orgUnit: alertTrackedEntity.orgUnit,
-                attributes: [
-                    {
-                        attribute: RTSL_ZEBRA_ALERTS_NATIONAL_DISEASE_OUTBREAK_EVENT_ID_TEA_ID,
-                        value: updatedMappedDiseaseOutbreakEventId,
-                    },
-                ],
-            };
-
-            return apiToFuture(
-                this.api.tracker.post(
-                    { importStrategy: "UPDATE" },
-                    { trackedEntities: [updatedAlert] }
-                )
-            ).flatMap(response => {
-                if (response.status === "ERROR")
-                    return Future.error(
-                        new Error(
-                            `Error updating mapped disease outbreak event id in alert ${alertId} with new value: ${updatedMappedDiseaseOutbreakEventId}`
-                        )
-                    );
-                else return Future.success(undefined);
-            });
-        });
+        ).flatMap(response =>
+            assertOrError(response.instances[0], `Alert tracked entity with id ${id}`)
+        );
     }
 
     updateAlertsPHEOCStatusByDiseaseOutbreakId(
@@ -347,3 +296,11 @@ export class AlertD2Repository implements AlertRepository {
         };
     }
 }
+const alertTrackerEntityFields = {
+    orgUnit: true,
+    attributes: true,
+    enrollments: true,
+    trackedEntityType: true,
+} as const;
+
+type AlertTrackerEntityFields = Partial<typeof alertTrackerEntityFields>;

--- a/src/data/repositories/test/AlertTestRepository.ts
+++ b/src/data/repositories/test/AlertTestRepository.ts
@@ -2,15 +2,15 @@ import { Alert } from "../../../domain/entities/alert/Alert";
 import { IncidentStatus } from "../../../domain/entities/disease-outbreak-event/PerformanceOverviewMetrics";
 import { Future } from "../../../domain/entities/generic/Future";
 import { Id } from "../../../domain/entities/Ref";
-import { AlertOptions, AlertRepository } from "../../../domain/repositories/AlertRepository";
+import {
+    AlertOptions,
+    AlertRepository,
+    UpdatePHEOCStatusOptions,
+} from "../../../domain/repositories/AlertRepository";
 import { FutureData } from "../../api-futures";
 
 export class AlertTestRepository implements AlertRepository {
-    updateAlertPHEOCStatus(
-        _alertId: Id,
-        _orgUnit: string,
-        _status: IncidentStatus
-    ): FutureData<void> {
+    updateAlertPHEOCStatus(_options: UpdatePHEOCStatusOptions): FutureData<void> {
         return Future.success(undefined);
     }
     getIncidentStatusByAlert(_alertId: Id): FutureData<IncidentStatus> {
@@ -19,14 +19,6 @@ export class AlertTestRepository implements AlertRepository {
     updateAlerts(_alertOptions: AlertOptions): FutureData<Alert[]> {
         return Future.success([]);
     }
-    updateMappedDiseaseOutbreakEventIdByPHEOCStatus(
-        _alertId: Id,
-        _status: IncidentStatus,
-        _diseaseOutbreakId?: Id
-    ): FutureData<void> {
-        return Future.success(undefined);
-    }
-
     getAlertById(alertId: Id): FutureData<Alert> {
         return Future.success({
             id: alertId,
@@ -34,7 +26,6 @@ export class AlertTestRepository implements AlertRepository {
             disease: "Disease",
         });
     }
-
     updateAlertsPHEOCStatusByDiseaseOutbreakId(
         _diseaseOutbreakId: Id,
         _pheocStatus: IncidentStatus

--- a/src/domain/repositories/AlertRepository.ts
+++ b/src/domain/repositories/AlertRepository.ts
@@ -7,16 +7,7 @@ import { Id } from "../entities/Ref";
 export interface AlertRepository {
     //TO DO : Remove this automatic mapping of alerts to disease as per R3 requirements.
     updateAlerts(alertOptions: AlertOptions): FutureData<Alert[]>;
-    updateAlertPHEOCStatus(
-        alertId: Id,
-        orgUnitName: string,
-        pheocStatus: IncidentStatus
-    ): FutureData<void>;
-    updateMappedDiseaseOutbreakEventIdByPHEOCStatus(
-        alertId: Id,
-        pheocStatus: IncidentStatus,
-        diseaseOutbreakId?: Id
-    ): FutureData<void>;
+    updateAlertPHEOCStatus(options: UpdatePHEOCStatusOptions): FutureData<void>;
     getIncidentStatusByAlert(alertId: Id): FutureData<Maybe<IncidentStatus>>;
     getAlertById(alertId: Id): FutureData<Alert>;
     updateAlertsPHEOCStatusByDiseaseOutbreakId(
@@ -30,4 +21,10 @@ export type OutbreakValueCode = string;
 export type AlertOptions = {
     eventId: Id;
     outbreakValue: Maybe<OutbreakValueCode>;
+};
+
+export type UpdatePHEOCStatusOptions = {
+    alertId: Id;
+    pheocStatus: IncidentStatus;
+    diseaseOutbreakId: Maybe<Id>;
 };

--- a/src/domain/usecases/UpdateAlertPHEOCStatusUseCase.ts
+++ b/src/domain/usecases/UpdateAlertPHEOCStatusUseCase.ts
@@ -17,7 +17,7 @@ export class UpdateAlertPHEOCStatusUseCase {
 
     public execute(alertId: Id, pheocStatus: IncidentStatus): FutureData<void> {
         return this.fetchAndValidateAlert(alertId)
-            .flatMap(this.fetchAndValidateDiseaseOutbreakEventId(pheocStatus))
+            .flatMap(this.fetchAndValidateMaybeDiseaseOutbreakEventId(pheocStatus))
             .flatMap(this.updateStatus(alertId, pheocStatus));
     }
 
@@ -34,7 +34,7 @@ export class UpdateAlertPHEOCStatusUseCase {
         });
     };
 
-    private fetchAndValidateDiseaseOutbreakEventId =
+    private fetchAndValidateMaybeDiseaseOutbreakEventId =
         (pheocStatus: IncidentStatus) =>
         (alert: Alert): FutureData<Maybe<Id>> => {
             if (pheocStatus === "Respond") {

--- a/src/domain/usecases/UpdateAlertPHEOCStatusUseCase.ts
+++ b/src/domain/usecases/UpdateAlertPHEOCStatusUseCase.ts
@@ -17,11 +17,13 @@ export class UpdateAlertPHEOCStatusUseCase {
 
     public execute(alertId: Id, pheocStatus: IncidentStatus): FutureData<void> {
         return this.fetchAndValidateAlert(alertId)
-            .flatMap(this.fetchAndValidateMaybeDiseaseOutbreakEventId(pheocStatus))
-            .flatMap(this.updateStatus(alertId, pheocStatus));
+            .flatMap(alert => this.fetchAndValidateMaybeDiseaseOutbreakEventId(pheocStatus, alert))
+            .flatMap(diseaseOutbreakId =>
+                this.updateStatus(alertId, pheocStatus, diseaseOutbreakId)
+            );
     }
 
-    private fetchAndValidateAlert = (alertId: Id): FutureData<Alert> => {
+    private fetchAndValidateAlert(alertId: Id): FutureData<Alert> {
         return this.options.alertRepository.getAlertById(alertId).flatMap(alert => {
             if (alert.status !== "ACTIVE") {
                 return Future.error(
@@ -32,38 +34,41 @@ export class UpdateAlertPHEOCStatusUseCase {
             }
             return Future.success(alert);
         });
-    };
+    }
 
-    private fetchAndValidateMaybeDiseaseOutbreakEventId =
-        (pheocStatus: IncidentStatus) =>
-        (alert: Alert): FutureData<Maybe<Id>> => {
-            if (pheocStatus === "Respond") {
-                return this.options.diseaseOutbreakEventRepository
-                    .getActiveByDisease(alert.disease)
-                    .flatMap(disease => {
-                        if (!disease?.id) {
-                            console.error(
-                                `No active disease outbreak event found for disease ${alert.disease}`
-                            );
-                            return Future.error(
-                                new Error(
-                                    `Error while updating PHEOC status to Respond in alert with id ${alert.id}`
-                                )
-                            );
-                        }
-                        return Future.success(disease?.id);
-                    });
-            }
-            return Future.success(undefined);
-        };
+    private fetchAndValidateMaybeDiseaseOutbreakEventId(
+        pheocStatus: IncidentStatus,
+        alert: Alert
+    ): FutureData<Maybe<Id>> {
+        if (pheocStatus === "Respond") {
+            return this.options.diseaseOutbreakEventRepository
+                .getActiveByDisease(alert.disease)
+                .flatMap(disease => {
+                    if (!disease?.id) {
+                        console.error(
+                            `No active disease outbreak event found for disease ${alert.disease}`
+                        );
+                        return Future.error(
+                            new Error(
+                                `Error while updating PHEOC status to Respond in alert with id ${alert.id}`
+                            )
+                        );
+                    }
+                    return Future.success(disease?.id);
+                });
+        }
+        return Future.success(undefined);
+    }
 
-    private updateStatus =
-        (alertId: Id, pheocStatus: IncidentStatus) =>
-        (diseaseOutbreakId: Maybe<Id>): FutureData<void> => {
-            return this.options.alertRepository.updateAlertPHEOCStatus({
-                alertId,
-                pheocStatus,
-                diseaseOutbreakId,
-            });
-        };
+    private updateStatus(
+        alertId: Id,
+        pheocStatus: IncidentStatus,
+        diseaseOutbreakId: Maybe<Id>
+    ): FutureData<void> {
+        return this.options.alertRepository.updateAlertPHEOCStatus({
+            alertId,
+            pheocStatus,
+            diseaseOutbreakId,
+        });
+    }
 }

--- a/src/domain/usecases/UpdateAlertPHEOCStatusUseCase.ts
+++ b/src/domain/usecases/UpdateAlertPHEOCStatusUseCase.ts
@@ -4,6 +4,8 @@ import { Future } from "../entities/generic/Future";
 import { Id } from "../entities/Ref";
 import { AlertRepository } from "../repositories/AlertRepository";
 import { DiseaseOutbreakEventRepository } from "../repositories/DiseaseOutbreakEventRepository";
+import { Maybe } from "../../utils/ts-utils";
+import { Alert } from "../entities/alert/Alert";
 
 export class UpdateAlertPHEOCStatusUseCase {
     constructor(
@@ -13,11 +15,13 @@ export class UpdateAlertPHEOCStatusUseCase {
         }
     ) {}
 
-    public execute(
-        alertId: Id,
-        orgUnitName: string,
-        pheocStatus: IncidentStatus
-    ): FutureData<void> {
+    public execute(alertId: Id, pheocStatus: IncidentStatus): FutureData<void> {
+        return this.fetchAndValidateAlert(alertId)
+            .flatMap(this.fetchAndValidateDiseaseOutbreakEventId(pheocStatus))
+            .flatMap(this.updateStatus(alertId, pheocStatus));
+    }
+
+    private fetchAndValidateAlert = (alertId: Id): FutureData<Alert> => {
         return this.options.alertRepository.getAlertById(alertId).flatMap(alert => {
             if (alert.status !== "ACTIVE") {
                 return Future.error(
@@ -26,34 +30,40 @@ export class UpdateAlertPHEOCStatusUseCase {
                     )
                 );
             }
-
-            return this.options.alertRepository
-                .updateAlertPHEOCStatus(alertId, orgUnitName, pheocStatus)
-                .flatMap(() => {
-                    const disease = alert.disease;
-                    const isNeededToMapWithDiseaseOutbreakEventId = pheocStatus === "Respond";
-
-                    if (isNeededToMapWithDiseaseOutbreakEventId) {
-                        return this.options.diseaseOutbreakEventRepository
-                            .getActiveByDisease(disease)
-                            .flatMap(maybeDiseaseOutbreakEvent => {
-                                if (maybeDiseaseOutbreakEvent) {
-                                    return this.options.alertRepository.updateMappedDiseaseOutbreakEventIdByPHEOCStatus(
-                                        alertId,
-                                        pheocStatus,
-                                        maybeDiseaseOutbreakEvent.id
-                                    );
-                                } else {
-                                    return Future.success(undefined);
-                                }
-                            });
-                    } else {
-                        return this.options.alertRepository.updateMappedDiseaseOutbreakEventIdByPHEOCStatus(
-                            alertId,
-                            pheocStatus
-                        );
-                    }
-                });
+            return Future.success(alert);
         });
-    }
+    };
+
+    private fetchAndValidateDiseaseOutbreakEventId =
+        (pheocStatus: IncidentStatus) =>
+        (alert: Alert): FutureData<Maybe<Id>> => {
+            if (pheocStatus === "Respond") {
+                return this.options.diseaseOutbreakEventRepository
+                    .getActiveByDisease(alert.disease)
+                    .flatMap(disease => {
+                        if (!disease?.id) {
+                            console.error(
+                                `No active disease outbreak event found for disease ${alert.disease}`
+                            );
+                            return Future.error(
+                                new Error(
+                                    `Error while updating PHEOC status to Respond in alert with id ${alert.id}`
+                                )
+                            );
+                        }
+                        return Future.success(disease?.id);
+                    });
+            }
+            return Future.success(undefined);
+        };
+
+    private updateStatus =
+        (alertId: Id, pheocStatus: IncidentStatus) =>
+        (diseaseOutbreakId: Maybe<Id>): FutureData<void> => {
+            return this.options.alertRepository.updateAlertPHEOCStatus({
+                alertId,
+                pheocStatus,
+                diseaseOutbreakId,
+            });
+        };
 }

--- a/src/webapp/components/visualisation/Visualisation.tsx
+++ b/src/webapp/components/visualisation/Visualisation.tsx
@@ -58,7 +58,7 @@ export const Visualisation: React.FC<VisualisationProps> = React.memo(props => {
 const VisualisationIFrame = styled.iframe``;
 
 const styles: Record<string, React.CSSProperties> = {
-    wrapperVisible: { width: "100%", height: "80vh" },
+    wrapperVisible: { width: "100%", height: "80vh", maxHeight: "850px" },
     wrapperHidden: { visibility: "hidden", width: "100%" },
 };
 

--- a/src/webapp/pages/dashboard/AlertsDashboard.tsx
+++ b/src/webapp/pages/dashboard/AlertsDashboard.tsx
@@ -61,7 +61,7 @@ export type AlertsDashboardProps = {
     eventSourceSelected: string;
     setEventSourceSelected: (selection: string) => void;
     hasEventSourceFilter?: boolean;
-    updateAlertIncidentStatus: (alertId: Id, orgUnitName: string, status: IncidentStatus) => void;
+    updateAlertIncidentStatus: (alertId: Id, status: IncidentStatus) => void;
 };
 
 export const AlertsDashboard: React.FC<AlertsDashboardProps> = React.memo(props => {
@@ -95,7 +95,7 @@ export const AlertsDashboard: React.FC<AlertsDashboardProps> = React.memo(props 
                     console.debug("Invalid incident status, not updating status");
                     return;
                 }
-                updateAlertIncidentStatus(alertId, orgUnitName, value);
+                updateAlertIncidentStatus(alertId, value);
             } else {
                 console.debug(`Unhandled column edit :  ${columnName}`);
             }

--- a/src/webapp/pages/dashboard/useAlertsPerformanceOverview.ts
+++ b/src/webapp/pages/dashboard/useAlertsPerformanceOverview.ts
@@ -65,7 +65,7 @@ type State = {
     eventSourceSelected: string;
     setEventSourceSelected: (selection: string) => void;
     hasEventSourceFilter?: boolean;
-    updateAlertIncidentStatus: (alertId: Id, orgUnitName: string, status: IncidentStatus) => void;
+    updateAlertIncidentStatus: (alertId: Id, status: IncidentStatus) => void;
 };
 
 export type Order = {
@@ -200,10 +200,10 @@ export function useAlertsPerformanceOverview(): State {
     ]);
 
     const updateAlertIncidentStatus = useCallback(
-        (alertId: Id, orgUnitName: string, status: IncidentStatus) => {
+        (alertId: Id, status: IncidentStatus) => {
             setIsLoading(true);
             compositionRoot.performanceOverview.updateAlertIncidentStatus
-                .execute(alertId, orgUnitName, status)
+                .execute(alertId, status)
                 .run(
                     () => {
                         snackbar.info("PHEOC status updated successfully!");


### PR DESCRIPTION
### :pushpin: References
-   **Issue:** Closes #?

### :memo: Implementation
- refactor update alert PHOEC usecase to update status and mapped eventid in one request to avoid bad data
- fix visualization zoom behavior (added max-height)

Context: previous version was functional but when I updated the status using very slow network, I got a timeout error in the middle of the flow. This resulted to alerts that have a "non-Respond" status but mapped to an event.

### :video_camera: Screenshots/Screen capture

### :fire: Notes to the tester
