### PR TITLE
Feature/dynamic default data source

### DIFF
--- a/src/CompositionRoot.ts
+++ b/src/CompositionRoot.ts
@@ -194,7 +194,7 @@ export function getWebappCompositionRoot(api: D2Api) {
         incidentManagementTeamRepository: new IncidentManagementTeamD2Repository(api),
         chartConfigRepository: new ChartConfigD2Repository(dataStoreClient),
         systemRepository: new SystemD2Repository(api),
-        configurationsRepository: new ConfigurationsD2Repository(api),
+        configurationsRepository: new ConfigurationsD2Repository(api, dataStoreClient),
         casesFileRepository: new CasesFileD2Repository(api, dataStoreClient),
         userGroupRepository: new UserGroupD2Repository(api),
         resourceRepository: new ResourceD2Repository(api),

--- a/src/data/entities/AppDatastoreConfig.ts
+++ b/src/data/entities/AppDatastoreConfig.ts
@@ -1,4 +1,4 @@
-import { Id } from "./Ref";
+import { Id } from "../../domain/entities/Ref";
 
 export type AppDatastoreConfig = {
     userGroups: {
@@ -9,5 +9,8 @@ export type AppDatastoreConfig = {
     casesFileTemplate: {
         fileId: Id;
         fileName: string;
+    };
+    appDefaults: {
+        diseaseOutbreakDataSource: string;
     };
 };

--- a/src/data/repositories/CasesFileD2Repository.ts
+++ b/src/data/repositories/CasesFileD2Repository.ts
@@ -7,7 +7,7 @@ import { Maybe } from "../../utils/ts-utils";
 import { Id } from "../../domain/entities/Ref";
 import { Future } from "../../domain/entities/generic/Future";
 import { CaseFile } from "../../domain/entities/CasesFile";
-import { AppDatastoreConfig } from "../../domain/entities/AppDatastoreConfig";
+import { AppDatastoreConfig } from "../entities/AppDatastoreConfig";
 
 export class CasesFileD2Repository implements CasesFileRepository {
     constructor(private api: D2Api, private dataStoreClient: DataStoreClient) {}

--- a/src/data/repositories/UserD2Repository.ts
+++ b/src/data/repositories/UserD2Repository.ts
@@ -1,6 +1,6 @@
 import { Future } from "../../domain/entities/generic/Future";
 import { User } from "../../domain/entities/User";
-import { AppDatastoreConfig } from "../../domain/entities/AppDatastoreConfig";
+import { AppDatastoreConfig } from "../entities/AppDatastoreConfig";
 import { UserRepository } from "../../domain/repositories/UserRepository";
 import { D2Api, MetadataPick } from "../../types/d2-api";
 import { apiToFuture, FutureData } from "../api-futures";

--- a/src/data/repositories/test/ConfigurationsTestRepository.ts
+++ b/src/data/repositories/test/ConfigurationsTestRepository.ts
@@ -1,7 +1,8 @@
-import { SelectableOptions } from "../../../domain/entities/AppConfigurations";
+import { AppDefaults, SelectableOptions } from "../../../domain/entities/AppConfigurations";
 import { Future } from "../../../domain/entities/generic/Future";
 import { ConfigurationsRepository } from "../../../domain/repositories/ConfigurationsRepository";
 import { FutureData } from "../../api-futures";
+import { DataSource } from "../../../domain/entities/disease-outbreak-event/DiseaseOutbreakEvent";
 
 export class ConfigurationsTestRepository implements ConfigurationsRepository {
     getSelectableOptions(): FutureData<SelectableOptions> {
@@ -48,6 +49,11 @@ export class ConfigurationsTestRepository implements ConfigurationsRepository {
                 status: [],
                 verification: [],
             },
+        });
+    }
+    getAppDefaults(): FutureData<AppDefaults> {
+        return Future.success({
+            diseaseOutbreakDataSource: DataSource.ND1,
         });
     }
 }

--- a/src/domain/entities/AppConfigurations.ts
+++ b/src/domain/entities/AppConfigurations.ts
@@ -27,6 +27,7 @@ import {
     Capability2,
 } from "./risk-assessment/RiskAssessmentGrading";
 import { UserGroup } from "./UserGroup";
+import { DataSource } from "./disease-outbreak-event/DiseaseOutbreakEvent";
 
 export type SelectableOptions = {
     eventTrackerConfigurations: DiseaseOutbreakEventOptions & DiseaseOutbreakCaseDataOptions;
@@ -57,4 +58,9 @@ export type Configurations = {
         responseOfficers: TeamMember[];
     };
     orgUnits: OrgUnit[];
+    appDefaults: AppDefaults;
+};
+
+export type AppDefaults = {
+    diseaseOutbreakDataSource: DataSource;
 };

--- a/src/domain/repositories/ConfigurationsRepository.ts
+++ b/src/domain/repositories/ConfigurationsRepository.ts
@@ -1,6 +1,7 @@
 import { FutureData } from "../../data/api-futures";
-import { SelectableOptions } from "../entities/AppConfigurations";
+import { AppDefaults, SelectableOptions } from "../entities/AppConfigurations";
 
 export interface ConfigurationsRepository {
     getSelectableOptions(): FutureData<SelectableOptions>;
+    getAppDefaults(): FutureData<AppDefaults>;
 }

--- a/src/domain/usecases/GetConfigurationsUseCase.ts
+++ b/src/domain/usecases/GetConfigurationsUseCase.ts
@@ -22,6 +22,7 @@ export class GetConfigurationsUseCase {
             managers: this.teamMemberRepository.getIncidentManagers(),
             riskAssessors: this.teamMemberRepository.getRiskAssessors(),
             selectableOptionsResponse: this.configurationsRepository.getSelectableOptions(),
+            appDefaults: this.configurationsRepository.getAppDefaults(),
             orgUnits: this.orgUnitRepository.getAll(),
             incidentManagerUserGroup: this.userGroupRepository.getIncidentManagerUserGroupByCode(),
         }).flatMap(
@@ -31,6 +32,7 @@ export class GetConfigurationsUseCase {
                 managers,
                 riskAssessors,
                 selectableOptionsResponse,
+                appDefaults,
                 orgUnits,
                 incidentManagerUserGroup,
             }) => {
@@ -52,6 +54,7 @@ export class GetConfigurationsUseCase {
                         responseOfficers: incidentResponseOfficers,
                     },
                     orgUnits,
+                    appDefaults,
                 };
                 return Future.success(configurations);
             }

--- a/src/scripts/mapDiseaseOutbreakToAlerts.ts
+++ b/src/scripts/mapDiseaseOutbreakToAlerts.ts
@@ -12,6 +12,7 @@ import { OutbreakAlertD2Repository } from "../data/repositories/OutbreakAlertD2R
 import { DiseaseOutbreakEventD2Repository } from "../data/repositories/DiseaseOutbreakEventD2Repository";
 import { ConfigurationsD2Repository } from "../data/repositories/ConfigurationsD2Repository";
 import { Future } from "../domain/entities/generic/Future";
+import { DataStoreClient } from "../data/DataStoreClient";
 
 function main() {
     const cmd = command({
@@ -28,13 +29,14 @@ function main() {
         },
         handler: async args => {
             const { api, instance } = getApiInstanceFromEnvVariables();
+            const dataStoreClient = new DataStoreClient(api);
 
             const alertRepository = new AlertD2Repository(api);
             const alertSyncRepository = new AlertSyncDataStoreRepository(api);
             const diseaseOutbreakEventRepository = new DiseaseOutbreakEventD2Repository(api);
             const notificationRepository = new NotificationD2Repository(api);
             const outbreakAlertRepository = new OutbreakAlertD2Repository(api);
-            const configurationsRepository = new ConfigurationsD2Repository(api);
+            const configurationsRepository = new ConfigurationsD2Repository(api, dataStoreClient);
             const userGroupRepository = new UserGroupD2Repository(api);
 
             const mapAndSaveAlertsUseCase = new MapAndSaveAlertsUseCase({

--- a/src/utils/tests.tsx
+++ b/src/utils/tests.tsx
@@ -11,6 +11,7 @@ import OldMuiThemeProvider from "material-ui/styles/MuiThemeProvider";
 import muiThemeLegacy from "../webapp/pages/app/themes/dhis2-legacy.theme";
 import { muiTheme } from "../webapp/pages/app/themes/dhis2.theme";
 import { D2Api } from "../types/d2-api";
+import { DataSource } from "../domain/entities/disease-outbreak-event/DiseaseOutbreakEvent";
 
 export function getTestContext() {
     const context: AppContextState = {
@@ -70,6 +71,9 @@ export function getTestContext() {
                 responseOfficers: [],
             },
             orgUnits: [],
+            appDefaults: {
+                diseaseOutbreakDataSource: DataSource.ND1,
+            },
         },
     };
 

--- a/src/webapp/components/date-picker/DatePicker.tsx
+++ b/src/webapp/components/date-picker/DatePicker.tsx
@@ -128,7 +128,9 @@ const StyledDatePicker = styled(DatePickerMUI)<{ error?: boolean; disabled?: boo
     }
     .MuiOutlinedInput-notchedOutline {
         border-color: ${props =>
-            props.error ? props.theme.palette.common.red600 : props.theme.palette.common.grey500};
+            props.error
+                ? props.theme.palette.common.red600
+                : props.theme.palette.common.grey500} !important;
     }
     .MuiIconButton-edgeEnd {
         color: ${props => props.theme.palette.icon.color};

--- a/src/webapp/pages/dashboard/useAlertsPerformanceOverview.ts
+++ b/src/webapp/pages/dashboard/useAlertsPerformanceOverview.ts
@@ -127,8 +127,6 @@ export function useAlertsPerformanceOverview(): State {
             { label: i18n.t("Province"), value: "province", type: "text" },
             { label: i18n.t("Organisation unit"), value: "orgUnit", type: "text" },
             { label: i18n.t("Organisation unit type"), value: "orgUnitType", type: "text" },
-            { label: i18n.t("Cases"), value: "cases", type: "text" },
-            { label: i18n.t("Deaths"), value: "deaths", type: "text" },
             { label: i18n.t("Duration"), value: "duration", type: "text" },
             { label: i18n.t("Manager"), value: "incidentManager", type: "text" },
             { label: i18n.t("Detect 7d"), dark: true, value: "detect7d", type: "text" },

--- a/src/webapp/pages/event-tracker/EventTrackerPage.tsx
+++ b/src/webapp/pages/event-tracker/EventTrackerPage.tsx
@@ -145,7 +145,7 @@ export const EventTrackerPage: React.FC = React.memo(() => {
                             label={i18n.t("Duration")}
                         />
                     </FilterContainer>
-                    {!isCasesDataUserDefined && mapDataSourceFilter.value && (
+                    {!isCasesDataUserDefined && (
                         <FilterContainer>
                             <Selector
                                 id={"filters-data-source"}
@@ -251,7 +251,7 @@ export const EventTrackerPage: React.FC = React.memo(() => {
             ) : null}
 
             <Section title={i18n.t("Overview")} hasSeparator={true} titleVariant="secondary">
-                {!isCasesDataUserDefined && overviewDataSourceFilter.value && (
+                {!isCasesDataUserDefined && (
                     <FiltersSection>
                         <FilterContainer>
                             <Selector
@@ -284,7 +284,7 @@ export const EventTrackerPage: React.FC = React.memo(() => {
                 titleVariant="secondary"
                 hasSeparator={true}
             >
-                {!isCasesDataUserDefined && chartsDataSourceFilter.value && (
+                {!isCasesDataUserDefined && (
                     <FiltersSection>
                         <FilterContainer>
                             <Selector

--- a/src/webapp/pages/event-tracker/useDataSourceFilter.ts
+++ b/src/webapp/pages/event-tracker/useDataSourceFilter.ts
@@ -1,18 +1,14 @@
-import { Maybe } from "../../../utils/ts-utils";
 import { Option } from "../../components/utils/option";
-import {
-    CasesDataSource,
-    DataSource,
-} from "../../../domain/entities/disease-outbreak-event/DiseaseOutbreakEvent";
+import { DataSource } from "../../../domain/entities/disease-outbreak-event/DiseaseOutbreakEvent";
 import { useMemo, useState } from "react";
 import { useAppContext } from "../../contexts/app-context";
 import { useCurrentEventTracker } from "../../contexts/current-event-tracker-context";
 
 export type DataSourceFiltersState = {
     onChange: (value: string) => void;
-    value: Maybe<string>;
+    value: string;
     options: Option[];
-    dataSource: Maybe<DataSource>;
+    dataSource: DataSource;
 };
 
 export function useDataSourceFilter() {
@@ -20,12 +16,7 @@ export function useDataSourceFilter() {
     const { getCurrentEventTracker } = useCurrentEventTracker();
     const currentEventTracker = getCurrentEventTracker();
 
-    const isCasesDataUserDefined =
-        currentEventTracker?.casesDataSource ===
-        CasesDataSource.RTSL_ZEB_OS_CASE_DATA_SOURCE_USER_DEF;
-
-    const defaultDataSource = (currentEventTracker?.dataSource || DataSource.ND1) as string;
-    const [dataSourceFilter, setDataSourceFilter] = useState(defaultDataSource);
+    const [dataSourceFilter, setDataSourceFilter] = useState("");
 
     const dataSourceOptions = useMemo(
         () =>
@@ -38,18 +29,14 @@ export function useDataSourceFilter() {
         [configurations]
     );
 
-    const dataSourceValue = useMemo(
-        () =>
-            isCasesDataUserDefined
-                ? {}
-                : {
-                      value: dataSourceFilter,
-                      dataSource:
-                          Object.values(DataSource).find(v => v === dataSourceFilter) ||
-                          DataSource.ND1,
-                  },
-        [isCasesDataUserDefined, dataSourceFilter]
-    );
+    const dataSourceValue = useMemo(() => {
+        const dataSource = dataSourceFilter || currentEventTracker?.dataSource;
+
+        return {
+            value: dataSource || DataSource.ND1.toString(),
+            dataSource: Object.values(DataSource).find(v => v === dataSource) || DataSource.ND1,
+        };
+    }, [dataSourceFilter, currentEventTracker]);
 
     return {
         onChange: setDataSourceFilter,

--- a/src/webapp/pages/form-page/disease-outbreak-event/mapFormStateToDiseaseOutbreakEvent.ts
+++ b/src/webapp/pages/form-page/disease-outbreak-event/mapFormStateToDiseaseOutbreakEvent.ts
@@ -2,7 +2,6 @@ import { DiseaseOutbreakEventFormData } from "../../../../domain/entities/Config
 import {
     DiseaseOutbreakEvent,
     CasesDataSource,
-    DataSource,
     DiseaseOutbreakEventBaseAttrs,
 } from "../../../../domain/entities/disease-outbreak-event/DiseaseOutbreakEvent";
 import { Maybe } from "../../../../utils/ts-utils";
@@ -18,12 +17,19 @@ import {
 import { FormState } from "../../../components/form/FormState";
 import { getCaseDataFromField } from "./CaseDataFileFieldHelper";
 import { diseaseOutbreakEventFieldIds } from "./mapDiseaseOutbreakEventToInitialFormState";
+import { AppDefaults } from "../../../../domain/entities/AppConfigurations";
+
+type MapFormStateToDiseaseOutbreakEventProps = {
+    formState: FormState;
+    currentUserName: string;
+    formData: DiseaseOutbreakEventFormData;
+    appDefaults: AppDefaults;
+};
 
 export function mapFormStateToDiseaseOutbreakEvent(
-    formState: FormState,
-    currentUserName: string,
-    formData: DiseaseOutbreakEventFormData
+    props: MapFormStateToDiseaseOutbreakEventProps
 ): DiseaseOutbreakEvent {
+    const { formState, currentUserName, formData, appDefaults } = props;
     const { entity: diseaseOutbreakEvent, type: formType } = formData;
     const allFields: FormFieldState[] = getAllFieldsFromSections(formState.sections);
 
@@ -31,7 +37,8 @@ export function mapFormStateToDiseaseOutbreakEvent(
         ? getDiseaseOutbreakEventFromDiseaseOutbreakForm(
               currentUserName,
               diseaseOutbreakEvent,
-              allFields
+              allFields,
+              appDefaults
           )
         : getDiseaseOutbreakEventFromDiseaseOutbreakCaseDataForm(
               currentUserName,
@@ -43,7 +50,8 @@ export function mapFormStateToDiseaseOutbreakEvent(
 function getDiseaseOutbreakEventFromDiseaseOutbreakForm(
     currentUserName: string,
     diseaseOutbreakEvent: Maybe<DiseaseOutbreakEvent>,
-    allFields: FormFieldState[]
+    allFields: FormFieldState[],
+    appDefaults: AppDefaults
 ): DiseaseOutbreakEvent {
     const diseaseOutbreakEventEditableData = {
         name: getStringFieldValue(diseaseOutbreakEventFieldIds.name, allFields),
@@ -177,7 +185,7 @@ function getDiseaseOutbreakEventFromDiseaseOutbreakForm(
         created: diseaseOutbreakEvent?.created,
         lastUpdated: diseaseOutbreakEvent?.lastUpdated,
         createdByName: diseaseOutbreakEvent?.createdByName || currentUserName,
-        dataSource: diseaseOutbreakEvent?.dataSource || DataSource.ND1,
+        dataSource: diseaseOutbreakEvent?.dataSource || appDefaults.diseaseOutbreakDataSource,
         ...diseaseOutbreakEventEditableData,
     };
     const newDiseaseOutbreakEvent = new DiseaseOutbreakEvent({

--- a/src/webapp/pages/form-page/mapFormStateToEntityData.ts
+++ b/src/webapp/pages/form-page/mapFormStateToEntityData.ts
@@ -48,20 +48,24 @@ import { TEAM_ROLE_FIELD_ID } from "./incident-management-team-member-assignment
 import { incidentManagementTeamBuilderCodesWithoutRoles } from "../../../data/repositories/consts/IncidentManagementTeamBuilderConstants";
 import { mapFormStateToDiseaseOutbreakEvent } from "./disease-outbreak-event/mapFormStateToDiseaseOutbreakEvent";
 import { Resource, ResourceType } from "../../../domain/entities/resources/Resource";
+import { AppDefaults } from "../../../domain/entities/AppConfigurations";
 
-export function mapFormStateToEntityData(
-    formState: FormState,
-    currentUserName: string,
-    formData: ConfigurableForm
-): ConfigurableForm {
+type MapFormStateToEntityDataProps = {
+    formState: FormState;
+    currentUserName: string;
+    formData: ConfigurableForm;
+    appDefaults: AppDefaults;
+};
+
+export function mapFormStateToEntityData(props: MapFormStateToEntityDataProps): ConfigurableForm {
+    const { formState, formData } = props;
     switch (formData.type) {
         case "disease-outbreak-event":
         case "disease-outbreak-event-case-data": {
-            const diseaseEntity = mapFormStateToDiseaseOutbreakEvent(
-                formState,
-                currentUserName,
-                formData
-            );
+            const diseaseEntity = mapFormStateToDiseaseOutbreakEvent({
+                ...props,
+                formData,
+            });
 
             const allFields: FormFieldState[] = getAllFieldsFromSections(formState.sections);
             const uploadedCasesDataFileValue = getFileFieldValue(

--- a/src/webapp/pages/form-page/useForm.ts
+++ b/src/webapp/pages/form-page/useForm.ts
@@ -366,11 +366,12 @@ export function useForm(formType: FormType, id?: Id): State {
     const onPrimaryButtonClick = useCallback(() => {
         if (formState.kind !== "loaded" || !configurableForm || !formState.data.isValid) return;
 
-        const formData = mapFormStateToEntityData(
-            formState.data,
-            currentUser.username,
-            configurableForm
-        );
+        const formData = mapFormStateToEntityData({
+            formState: formState.data,
+            currentUserName: currentUser.username,
+            formData: configurableForm,
+            appDefaults: configurations.appDefaults,
+        });
 
         if (
             formData.type === "disease-outbreak-event" ||


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #8698qzke0 [Make Changes to Create Event Form](https://app.clickup.com/t/8698qzke0)

### :memo: Implementation
- add appDefaults in AppConfiguration and in `app-config` datastore key
- add fetching of app defaults in `ConfigurationsRepository.ts`
- remove cases and deaths from alerts dashboard table

additional changes:
- moved `AppDatastoreConfig.ts` to data layer
- fix red border on empty datePickers in edit event form (no errors detected, just styling issues) 
- updating some logic in `useDataSourceFilter.ts`. Event datasource not used in filters by default when loading from dashboard

### :video_camera: Screenshots/Screen capture

https://github.com/user-attachments/assets/fd2f41f3-5ffa-465a-9f6e-bb09d5b45add

### :fire: Notes to the tester
