### PR TITLE
Fix: Add missing data element when try to create National event User defined

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2025-06-04T08:10:34.122Z\n"
-"PO-Revision-Date: 2025-06-04T08:10:34.122Z\n"
+"POT-Creation-Date: 2025-06-10T11:07:30.717Z\n"
+"PO-Revision-Date: 2025-06-10T11:07:30.717Z\n"
 
 msgid "Low"
 msgstr ""
@@ -237,12 +237,6 @@ msgstr ""
 msgid "Organisation unit type"
 msgstr ""
 
-msgid "Cases"
-msgstr ""
-
-msgid "Deaths"
-msgstr ""
-
 msgid "Manager"
 msgstr ""
 
@@ -265,6 +259,12 @@ msgid "Outbreak Id"
 msgstr ""
 
 msgid "Event"
+msgstr ""
+
+msgid "Cases"
+msgstr ""
+
+msgid "Deaths"
 msgstr ""
 
 msgid "ERA1"

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2025-06-04T08:10:34.122Z\n"
+"POT-Creation-Date: 2025-06-10T11:07:30.717Z\n"
 "PO-Revision-Date: 2018-10-25T09:02:35.143Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -236,12 +236,6 @@ msgstr ""
 msgid "Organisation unit type"
 msgstr ""
 
-msgid "Cases"
-msgstr ""
-
-msgid "Deaths"
-msgstr ""
-
 msgid "Manager"
 msgstr ""
 
@@ -264,6 +258,12 @@ msgid "Outbreak Id"
 msgstr ""
 
 msgid "Event"
+msgstr ""
+
+msgid "Cases"
+msgstr ""
+
+msgid "Deaths"
 msgstr ""
 
 msgid "ERA1"

--- a/src/data/repositories/consts/CaseDataConstants.ts
+++ b/src/data/repositories/consts/CaseDataConstants.ts
@@ -17,6 +17,7 @@ export const casesDataCodes = {
     confirmedCases: "RTSL_ZEB_DET_CONF_CASES",
     deaths: "RTSL_ZEB_DET_DEATHS",
     diseaseOutbreakId: "RTSL_ZEB_DET_NATIONAL_EVENT_ID",
+    dataSource: "RTSL_ZEB_DET_DATA_SOURCE",
 } as const;
 
 export type CasesDataCode = GetValue<typeof casesDataCodes>;
@@ -47,5 +48,6 @@ export function getCasesDataValuesFromDiseaseOutbreak(
         RTSL_ZEB_DET_CONF_CASES: caseData.confirmedCases.toString(),
         RTSL_ZEB_DET_DEATHS: caseData.deaths.toString(),
         RTSL_ZEB_DET_NATIONAL_EVENT_ID: nationalEventId,
+        RTSL_ZEB_DET_DATA_SOURCE: "",
     };
 }

--- a/src/webapp/pages/event-tracker/useDataSourceFilter.ts
+++ b/src/webapp/pages/event-tracker/useDataSourceFilter.ts
@@ -1,14 +1,18 @@
 import { Option } from "../../components/utils/option";
-import { DataSource } from "../../../domain/entities/disease-outbreak-event/DiseaseOutbreakEvent";
+import {
+    CasesDataSource,
+    DataSource,
+} from "../../../domain/entities/disease-outbreak-event/DiseaseOutbreakEvent";
 import { useMemo, useState } from "react";
 import { useAppContext } from "../../contexts/app-context";
 import { useCurrentEventTracker } from "../../contexts/current-event-tracker-context";
+import { Maybe } from "../../../utils/ts-utils";
 
 export type DataSourceFiltersState = {
     onChange: (value: string) => void;
     value: string;
     options: Option[];
-    dataSource: DataSource;
+    dataSource: Maybe<DataSource>;
 };
 
 export function useDataSourceFilter() {
@@ -31,10 +35,15 @@ export function useDataSourceFilter() {
 
     const dataSourceValue = useMemo(() => {
         const dataSource = dataSourceFilter || currentEventTracker?.dataSource;
+        const isCasesDataUserDefined =
+            currentEventTracker?.casesDataSource ===
+            CasesDataSource.RTSL_ZEB_OS_CASE_DATA_SOURCE_USER_DEF;
 
         return {
             value: dataSource || DataSource.ND1.toString(),
-            dataSource: Object.values(DataSource).find(v => v === dataSource) || DataSource.ND1,
+            dataSource: isCasesDataUserDefined
+                ? undefined
+                : Object.values(DataSource).find(v => v === dataSource) || DataSource.ND1,
         };
     }, [dataSourceFilter, currentEventTracker]);
 


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #?

### :memo: Implementation
- Add missing data source data element and save to empty when user defined event

### :video_camera: Screenshots/Screen capture

### :fire: Notes to the tester

National Event:  Zika Fever (test User Defined)
https://metadata.eyeseetea.com/rsl-zebra240/api/apps/ZEBRA/index.html#/event-tracker/TvATEIa9dwb

Cases data:
https://metadata.eyeseetea.com/rsl-zebra240/dhis-web-capture/index.html#/viewEvent?viewEventId=c0nUOfdgLZK
https://metadata.eyeseetea.com/rsl-zebra240/dhis-web-capture/index.html#/viewEvent?viewEventId=i9VbjSuwltF
https://metadata.eyeseetea.com/rsl-zebra240/dhis-web-capture/index.html#/viewEvent?viewEventId=Fosfq9rNi8H

File uploaded:
[CASES_DATA_TEMPLATE.xlsx](https://github.com/user-attachments/files/20671974/CASES_DATA_TEMPLATE.xlsx)

It seems that at least these indicators were not OK, Active filter was missing:
https://metadata.eyeseetea.com/rsl-zebra240/dhis-web-maintenance/index.html#/edit/indicatorSection/programIndicator/R1Am1lGGNqB
https://metadata.eyeseetea.com/rsl-zebra240/dhis-web-maintenance/index.html#/edit/indicatorSection/programIndicator/c6v0QbJIoc6
https://metadata.eyeseetea.com/rsl-zebra240/dhis-web-maintenance/index.html#/edit/indicatorSection/programIndicator/fWq6jcAU1Mg

overview cards: https://metadata.eyeseetea.com/rsl-zebra240/api/apps/line-listing/index.html#/bS1GsGjChUh

