### PR TITLE
Fix: Allow to update alert to Respond Status without a disease outbreak event already created

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2025-06-04T08:10:34.122Z\n"
-"PO-Revision-Date: 2025-06-04T08:10:34.122Z\n"
+"POT-Creation-Date: 2025-06-11T12:01:49.186Z\n"
+"PO-Revision-Date: 2025-06-11T12:01:49.186Z\n"
 
 msgid "Low"
 msgstr ""
@@ -237,12 +237,6 @@ msgstr ""
 msgid "Organisation unit type"
 msgstr ""
 
-msgid "Cases"
-msgstr ""
-
-msgid "Deaths"
-msgstr ""
-
 msgid "Manager"
 msgstr ""
 
@@ -265,6 +259,12 @@ msgid "Outbreak Id"
 msgstr ""
 
 msgid "Event"
+msgstr ""
+
+msgid "Cases"
+msgstr ""
+
+msgid "Deaths"
 msgstr ""
 
 msgid "ERA1"

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2025-06-04T08:10:34.122Z\n"
+"POT-Creation-Date: 2025-06-11T12:01:49.186Z\n"
 "PO-Revision-Date: 2018-10-25T09:02:35.143Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -236,12 +236,6 @@ msgstr ""
 msgid "Organisation unit type"
 msgstr ""
 
-msgid "Cases"
-msgstr ""
-
-msgid "Deaths"
-msgstr ""
-
 msgid "Manager"
 msgstr ""
 
@@ -264,6 +258,12 @@ msgid "Outbreak Id"
 msgstr ""
 
 msgid "Event"
+msgstr ""
+
+msgid "Cases"
+msgstr ""
+
+msgid "Deaths"
 msgstr ""
 
 msgid "ERA1"

--- a/src/domain/usecases/UpdateAlertPHEOCStatusUseCase.ts
+++ b/src/domain/usecases/UpdateAlertPHEOCStatusUseCase.ts
@@ -43,18 +43,14 @@ export class UpdateAlertPHEOCStatusUseCase {
         if (pheocStatus === "Respond") {
             return this.options.diseaseOutbreakEventRepository
                 .getActiveByDisease(alert.disease)
-                .flatMap(disease => {
-                    if (!disease?.id) {
+                .flatMap(maybeDiseaseOutbreakEvent => {
+                    if (!maybeDiseaseOutbreakEvent?.id) {
                         console.error(
                             `No active disease outbreak event found for disease ${alert.disease}`
                         );
-                        return Future.error(
-                            new Error(
-                                `Error while updating PHEOC status to Respond in alert with id ${alert.id}`
-                            )
-                        );
+                        return Future.success(undefined);
                     }
-                    return Future.success(disease?.id);
+                    return Future.success(maybeDiseaseOutbreakEvent.id);
                 });
         }
         return Future.success(undefined);


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #?

### :memo: Implementation
- Fix: Allow to update alert to Respond Status without a disease outbreak event already created

### :video_camera: Screenshots/Screen capture

[Screencast from 2025-06-11 14-05-26.webm](https://github.com/user-attachments/assets/5ff37e52-ef1c-4910-bb5c-121a9656923b)



### :fire: Notes to the tester
