### PR TITLE
Add same date format for all performance tables in UI

### DIFF
--- a/src/data/repositories/PerformanceOverviewD2Repository.ts
+++ b/src/data/repositories/PerformanceOverviewD2Repository.ts
@@ -49,7 +49,6 @@ import { AlertDataSource } from "../../domain/entities/alert/Alert";
 import { orgUnitLevelTypeByLevelNumber } from "../../domain/entities/OrgUnit";
 import { VerificationStatus } from "../../domain/entities/alert/Alert";
 import _c from "../../domain/entities/generic/Collection";
-import { getDateAsMonthYearString } from "./utils/DateTimeHelper";
 import { programStatusOptions } from "./utils/getAllTrackedEntities";
 
 const formatDate = (date: Date): string => {
@@ -628,11 +627,10 @@ export class PerformanceOverviewD2Repository implements PerformanceOverviewRepos
                                             ].includes(dimensionKey)
                                         ) {
                                             const inputDate = row[index];
+
                                             return {
                                                 ...acc,
-                                                [dimensionKey]: inputDate
-                                                    ? getDateAsMonthYearString(new Date(inputDate))
-                                                    : null,
+                                                [dimensionKey]: inputDate,
                                             };
                                         } else if (dimension === "ounamehierarchy") {
                                             const hierarchyArray = row[index]?.split("/");

--- a/src/webapp/components/utils/getDateStringAsMonthYearString.ts
+++ b/src/webapp/components/utils/getDateStringAsMonthYearString.ts
@@ -1,0 +1,15 @@
+export function getDateStringAsMonthYearString(dateString: string): string {
+    try {
+        if (!dateString) return "";
+
+        const date = new Date(dateString);
+        return date.toLocaleString("default", {
+            day: "numeric",
+            month: "long",
+            year: "numeric",
+        });
+    } catch (e) {
+        console.debug(e);
+        return "";
+    }
+}

--- a/src/webapp/pages/dashboard/useAlertsPerformanceOverview.ts
+++ b/src/webapp/pages/dashboard/useAlertsPerformanceOverview.ts
@@ -23,6 +23,7 @@ import {
     UNKNOWN_DISEASE_NAME,
 } from "../../../domain/entities/disease-outbreak-event/PerformanceOverviewMetrics";
 import { incidentStatusOptions } from "./useAlertsActiveVerifiedFilters";
+import { getDateStringAsMonthYearString } from "../../components/utils/getDateStringAsMonthYearString";
 
 export type AlertsPerformanceOverviewMetricsTableData = {
     teiId: Id;
@@ -201,6 +202,10 @@ export function useAlertsPerformanceOverview(): State {
             const incidentManager = allTeamMembers.find(tm => tm.name === data.incidentManager);
             return {
                 ...data,
+                emergedDate: getDateStringAsMonthYearString(data.emergedDate),
+                notifiedDate: getDateStringAsMonthYearString(data.notifiedDate),
+                respondedDate: getDateStringAsMonthYearString(data.respondedDate),
+                detectionDate: getDateStringAsMonthYearString(data.detectionDate),
                 incidentManager: incidentManager?.name || data.incidentManager,
                 incidentManagerUsername: incidentManager?.username || "",
                 province: data.province.trim(),

--- a/src/webapp/pages/dashboard/useNationalPerformanceOverview.ts
+++ b/src/webapp/pages/dashboard/useNationalPerformanceOverview.ts
@@ -16,6 +16,7 @@ import i18n from "../../../utils/i18n";
 import { TeamMember } from "../../../domain/entities/incident-management-team/TeamMember";
 import { Option } from "../../components/utils/option";
 import { Id } from "../../../domain/entities/Ref";
+import { getDateStringAsMonthYearString } from "../../components/utils/getDateStringAsMonthYearString";
 
 export type PerformanceOverviewMetricsTableData = {
     id: Id;
@@ -160,6 +161,7 @@ export function useNationalPerformanceOverview(): State {
             return {
                 ...programIndicator,
                 event: programIndicator.event,
+                date: getDateStringAsMonthYearString(programIndicator.date),
                 incidentManager: incidentManagerName || programIndicator.incidentManagerUsername,
             };
         },


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #8699901qj[Add same date format for all performance tables in UI](https://app.clickup.com/t/8699901qj)

### :memo: Implementation
- Add same date format for all performance tables in UI (move format date to presentation layer)

### :video_camera: Screenshots/Screen capture

<img width="1645" height="616" alt="Screenshot from 2025-08-26 14-59-58" src="https://github.com/user-attachments/assets/e5fa0daf-ae51-4930-82d4-c9a66b17b39b" />


### :fire: Notes to the tester
