### PR TITLE
Sum ND1 and ND2 cases and deaths in ZEBRA performance overview table

### DIFF
--- a/src/data/repositories/PerformanceOverviewD2Repository.ts
+++ b/src/data/repositories/PerformanceOverviewD2Repository.ts
@@ -547,15 +547,15 @@ export class PerformanceOverviewD2Repository implements PerformanceOverviewRepos
         currentCases: number;
         currentDeaths: number;
     } {
-        const currentEventTrackerOverview = eventTrackerOverviewsForKeys.filter(
+        const currentEventTrackerOverviews = eventTrackerOverviewsForKeys.filter(
             overview => overview.key === diseaseCode
         );
 
-        const allSuspectedCasesIds = currentEventTrackerOverview.map(
+        const allSuspectedCasesIds = currentEventTrackerOverviews.map(
             overview => overview.suspectedCasesId
         );
 
-        const allDeathsIds = currentEventTrackerOverview.map(overview => overview.deathsId);
+        const allDeathsIds = currentEventTrackerOverviews.map(overview => overview.deathsId);
 
         const currentCases = allCases.filter(caseIdValue =>
             allSuspectedCasesIds.includes(caseIdValue.id)

--- a/src/data/repositories/PerformanceOverviewD2Repository.ts
+++ b/src/data/repositories/PerformanceOverviewD2Repository.ts
@@ -551,17 +551,19 @@ export class PerformanceOverviewD2Repository implements PerformanceOverviewRepos
             overview => overview.key === diseaseCode
         );
 
-        const allSuspectedCasesIds = currentEventTrackerOverviews.map(
-            overview => overview.suspectedCasesId
+        const allSuspectedCasesIds = new Set(
+            currentEventTrackerOverviews.map(overview => overview.suspectedCasesId)
         );
 
-        const allDeathsIds = currentEventTrackerOverviews.map(overview => overview.deathsId);
+        const allDeathsIds = new Set(
+            currentEventTrackerOverviews.map(overview => overview.deathsId)
+        );
 
         const currentCases = allCases.filter(caseIdValue =>
-            allSuspectedCasesIds.includes(caseIdValue.id)
+            allSuspectedCasesIds.has(caseIdValue.id)
         );
 
-        const currentDeaths = allDeaths.filter(death => allDeathsIds.includes(death.id));
+        const currentDeaths = allDeaths.filter(death => allDeathsIds.has(death.id));
 
         const sumValues = (currentValues: IdValue[]) =>
             currentValues.reduce((acc, curr) => {

--- a/src/data/repositories/PerformanceOverviewD2Repository.ts
+++ b/src/data/repositories/PerformanceOverviewD2Repository.ts
@@ -458,9 +458,7 @@ export class PerformanceOverviewD2Repository implements PerformanceOverviewRepos
                                     overview => {
                                         const event = diseaseOutbreakEventsMap.get(overview.key);
                                         return (
-                                            !!event &&
-                                            ((!event.dataSource && !overview.dataSource) ||
-                                                (!!event.dataSource && !!overview.dataSource))
+                                            !!event && !!event.dataSource === !!overview.dataSource
                                         );
                                     }
                                 );

--- a/src/data/repositories/PerformanceOverviewD2Repository.ts
+++ b/src/data/repositories/PerformanceOverviewD2Repository.ts
@@ -31,7 +31,7 @@ import {
     TotalPerformanceMetrics717,
     PerformanceMetricsStatus,
 } from "../../domain/entities/disease-outbreak-event/PerformanceOverviewMetrics";
-import { Id } from "../../domain/entities/Ref";
+import { Code, Id } from "../../domain/entities/Ref";
 import { OverviewCard } from "../../domain/entities/PerformanceOverview";
 import { assertOrError } from "./utils/AssertOrError";
 import {
@@ -460,7 +460,7 @@ export class PerformanceOverviewD2Repository implements PerformanceOverviewRepos
                                         return (
                                             !!event &&
                                             ((!event.dataSource && !overview.dataSource) ||
-                                                event.dataSource === overview.dataSource)
+                                                (!!event.dataSource && !!overview.dataSource))
                                         );
                                     }
                                 );
@@ -489,22 +489,14 @@ export class PerformanceOverviewD2Repository implements PerformanceOverviewRepos
                                                         `No suspected disease found for event : ${event.id}`
                                                     )
                                                 );
-                                            const currentEventTrackerOverview =
-                                                eventTrackerOverviewsForKeys.find(
-                                                    overview => overview.key === key
+
+                                            const casesAndDeaths =
+                                                this.getCasesAndDeathsFromBothDataSourcesByDisease(
+                                                    key,
+                                                    eventTrackerOverviewsForKeys,
+                                                    allCases,
+                                                    allDeaths
                                                 );
-
-                                            const currentCases = allCases.find(
-                                                caseIdValue =>
-                                                    caseIdValue.id ===
-                                                    currentEventTrackerOverview?.suspectedCasesId
-                                            );
-
-                                            const currentDeaths = allDeaths.find(
-                                                death =>
-                                                    death.id ===
-                                                    currentEventTrackerOverview?.deathsId
-                                            );
 
                                             //TODO: 8698prv94 - replace with correct
                                             const duration = `${moment()
@@ -518,8 +510,10 @@ export class PerformanceOverviewD2Repository implements PerformanceOverviewRepos
                                                     incidentManagerUsername:
                                                         event.incidentManagerName,
                                                     duration: duration,
-                                                    cases: currentCases?.value || "",
-                                                    deaths: currentDeaths?.value || "",
+                                                    cases:
+                                                        String(casesAndDeaths.currentCases) || "",
+                                                    deaths:
+                                                        String(casesAndDeaths.currentDeaths) || "",
                                                 } as PerformanceOverviewMetrics;
                                                 return Future.success(metrics);
                                             } else {
@@ -528,8 +522,10 @@ export class PerformanceOverviewD2Repository implements PerformanceOverviewRepos
                                                     incidentManagerUsername:
                                                         event.incidentManagerName,
                                                     duration: duration,
-                                                    cases: currentCases?.value || "",
-                                                    deaths: currentDeaths?.value || "",
+                                                    cases:
+                                                        String(casesAndDeaths.currentCases) || "",
+                                                    deaths:
+                                                        String(casesAndDeaths.currentDeaths) || "",
                                                 } as PerformanceOverviewMetrics;
                                                 return Future.success(metrics);
                                             }
@@ -542,6 +538,47 @@ export class PerformanceOverviewD2Repository implements PerformanceOverviewRepos
                     });
                 });
             });
+    }
+
+    private getCasesAndDeathsFromBothDataSourcesByDisease(
+        diseaseCode: Code,
+        eventTrackerOverviewsForKeys: EventTrackerOverviewInDataStore[],
+        allCases: IdValue[],
+        allDeaths: IdValue[]
+    ): {
+        currentCases: number;
+        currentDeaths: number;
+    } {
+        const currentEventTrackerOverview = eventTrackerOverviewsForKeys.filter(
+            overview => overview.key === diseaseCode
+        );
+
+        const allSuspectedCasesIds = currentEventTrackerOverview.map(
+            overview => overview.suspectedCasesId
+        );
+
+        const allDeathsIds = currentEventTrackerOverview.map(overview => overview.deathsId);
+
+        const currentCases = allCases.filter(caseIdValue =>
+            allSuspectedCasesIds.includes(caseIdValue.id)
+        );
+
+        const currentDeaths = allDeaths.filter(death => allDeathsIds.includes(death.id));
+
+        const sumValues = (currentValues: IdValue[]) =>
+            currentValues.reduce((acc, curr) => {
+                const number = Number.isFinite(Number(curr.value)) ? Number(curr.value) : 0;
+                return acc + number;
+            }, 0);
+
+        const sumCurrentCases = sumValues(currentCases);
+
+        const sumCurrentDeaths = sumValues(currentDeaths);
+
+        return {
+            currentCases: sumCurrentCases,
+            currentDeaths: sumCurrentDeaths,
+        };
     }
 
     getAlertsPerformanceOverviewMetrics(): FutureData<AlertsPerformanceOverviewMetrics[]> {


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #8699901qj [Error in cases/deaths performance overview table](https://app.clickup.com/t/8699901qj)

### :memo: Implementation
- Sum ND1 and ND2 cases and deaths in ZEBRA performance overview table (before only showed the values from default data source) 

### :video_camera: Screenshots/Screen capture

TEST: 
<img width="1629" height="572" alt="Screenshot from 2025-08-29 10-20-16" src="https://github.com/user-attachments/assets/ab461b1f-61bf-42e7-9a9c-ca957a995863" />
<img width="1629" height="572" alt="Screenshot from 2025-08-29 10-20-12" src="https://github.com/user-attachments/assets/a83888e8-3376-41c8-8bb0-d7a350666629" />


<img width="1206" height="675" alt="Screenshot from 2025-08-29 10-20-01" src="https://github.com/user-attachments/assets/63e97431-3cf3-4dcb-9a55-0be15667ea67" />


### :fire: Notes to the tester
