### PR TITLE
fix event page associated events date format

### DIFF
--- a/src/webapp/pages/event-tracker/useMappedAlerts.ts
+++ b/src/webapp/pages/event-tracker/useMappedAlerts.ts
@@ -25,6 +25,7 @@ import {
     DAYS_RESPONSE,
     getColor,
 } from "../common/717Performance";
+import { getDateStringAsMonthYearString } from "../../components/utils/getDateStringAsMonthYearString";
 
 type State = {
     columns: TableColumn[];
@@ -129,8 +130,13 @@ export function useMappedAlerts(diseaseOutbreakId: Id): State {
 
             return {
                 ...data,
+                emergedDate: getDateStringAsMonthYearString(data.emergedDate),
+                notifiedDate: getDateStringAsMonthYearString(data.notifiedDate),
+                respondedDate: getDateStringAsMonthYearString(data.respondedDate),
+                detectionDate: getDateStringAsMonthYearString(data.detectionDate),
                 incidentManager: incidentManager?.name || data.incidentManager,
                 incidentManagerUsername: incidentManager?.username || "",
+                province: data.province.trim(),
             };
         },
         []


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #869ac08vg [Date Format to be corrected](https://app.clickup.com/t/869ac08vg)

### :memo: Implementation
- fix date format in events tracker page

### :video_camera: Screenshots/Screen capture
<img width="1148" height="581" alt="image" src="https://github.com/user-attachments/assets/204ab1fb-b1fb-4fb6-8656-1e51f0796d60" />

### :fire: Notes to the tester
