### PR TITLE
Ignore timestamp when calculating durations

### DIFF
--- a/src/data/repositories/PerformanceOverviewD2Repository.ts
+++ b/src/data/repositories/PerformanceOverviewD2Repository.ts
@@ -497,7 +497,8 @@ export class PerformanceOverviewD2Repository implements PerformanceOverviewRepos
 
                                             //TODO: 8698prv94 - replace with correct
                                             const duration = `${moment()
-                                                .diff(moment(event.created), "days")
+                                                .startOf("day")
+                                                .diff(moment(event.created).startOf("day"), "days")
                                                 .toString()}d`;
 
                                             if (!baseIndicator) {


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #869ac0t9v [Duration Calculation Incorrect for Zebra Event](https://app.clickup.com/t/869ac0t9v)

### :memo: Implementation
- ignore timestamp when calculating durations

### :video_camera: Screenshots/Screen capture
<img width="1052" height="661" alt="image" src="https://github.com/user-attachments/assets/e45d5b21-b7d3-471e-ab12-ff68abf6dd7d" />

### :fire: Notes to the tester
