### PR TITLE
fix: performance overview duration calculation

### DIFF
--- a/src/data/repositories/PerformanceOverviewD2Repository.ts
+++ b/src/data/repositories/PerformanceOverviewD2Repository.ts
@@ -495,11 +495,15 @@ export class PerformanceOverviewD2Repository implements PerformanceOverviewRepos
                                                     allDeaths
                                                 );
 
-                                            //TODO: 8698prv94 - replace with correct
                                             const duration = `${moment()
+                                                .utc()
                                                 .startOf("day")
-                                                .diff(moment(event.created).startOf("day"), "days")
-                                                .toString()}d`;
+                                                .diff(
+                                                    moment(event.created).utc().startOf("day"),
+                                                    "days"
+                                                )}d`;
+
+                                            console.log(event.created, duration, event.id);
 
                                             if (!baseIndicator) {
                                                 const metrics = {

--- a/src/data/repositories/PerformanceOverviewD2Repository.ts
+++ b/src/data/repositories/PerformanceOverviewD2Repository.ts
@@ -503,8 +503,6 @@ export class PerformanceOverviewD2Repository implements PerformanceOverviewRepos
                                                     "days"
                                                 )}d`;
 
-                                            console.log(event.created, duration, event.id);
-
                                             if (!baseIndicator) {
                                                 const metrics = {
                                                     id: event.id,


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #869ac0t9v [Duration Calculation Incorrect for Zebra Event](https://app.clickup.com/t/869ac0t9v)

### :memo: Implementation
- use utc startOf day when calculating diff for duration


Details:
- initial fix was to ignore timestamp https://github.com/EyeSeeTea/zebra-dev/pull/104
- Without UTC, the diff was off by -1 in negative UTC timezones.
- **Sample at UTC-8**
    - `getISODateAsLocaleDateString("2025-08-27T15:19:16.435")` ->  `Aug 27, 2025 07:19` -> startOf day `Aug 27, 2025 00:00` 
    -> diff with today at UTC-8 is `Sept 8, 2025 00:00` -> **12d**

- **fix:** get diff as utc times
    - `getISODateAsLocaleDateString("2025-08-27T15:19:16.435")` ->  `Aug 27, 2025 07:19` -> UTC startOf day `Aug 27, 2025 00:00` 
    -> diff with UTC today is `Sept 9, 2025 00:00` -> **13d**


### :video_camera: Screenshots/Screen capture
updated system time to UTC-8 and then restarted browser
<img width="1752" height="717" alt="image" src="https://github.com/user-attachments/assets/10391d70-47ab-4e13-99b5-c58e1ecfcece" />

### :fire: Notes to the tester
