### PR TITLE
End Date for Duration Filter is Setting incorrectly

### DIFF
--- a/src/webapp/components/date-picker/DatePicker.tsx
+++ b/src/webapp/components/date-picker/DatePicker.tsx
@@ -38,11 +38,11 @@ export const DatePicker: React.FC<DatePickerProps> = React.memo(
     }) => {
         const notifyChange = useCallback(
             (date: Date | null) => {
-                onChange(
-                    date
-                        ? new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()))
-                        : null
-                );
+                const normalizedDate = date
+                    ? new Date(date.getFullYear(), date.getMonth(), date.getDate())
+                    : null;
+
+                onChange(normalizedDate);
             },
             [onChange]
         );

--- a/src/webapp/components/date-picker/DateRangePicker.tsx
+++ b/src/webapp/components/date-picker/DateRangePicker.tsx
@@ -1,13 +1,14 @@
-import i18n from "../../../utils/i18n";
 import React, { useState, useMemo, useCallback } from "react";
 import { Popover, InputAdornment, TextField, InputLabel } from "@material-ui/core";
 import moment from "moment";
+import styled from "styled-components";
 import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
-import { DatePicker } from "./DatePicker";
 import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFns";
 import { IconCalendar24 } from "@dhis2/ui";
+
+import i18n from "../../../utils/i18n";
+import { DatePicker } from "./DatePicker";
 import { Button } from "../button/Button";
-import styled from "styled-components";
 
 type DateRangePickerProps = {
     label?: string;
@@ -49,8 +50,10 @@ export const DateRangePicker: React.FC<DateRangePickerProps> = React.memo(
                 return placeholder;
             }
 
-            return `${moment(new Date(value[0])).format("DD/MM/yyyy")} — ${moment(
-                new Date(value[1])
+            return `${moment(value[0], "YYYY-MM-DD", true).format("DD/MM/yyyy")} — ${moment(
+                value[1],
+                "YYYY-MM-DD",
+                true
             ).format("DD/MM/yyyy")}`;
         }, [placeholder, value]);
 
@@ -63,10 +66,10 @@ export const DateRangePicker: React.FC<DateRangePickerProps> = React.memo(
         const onSave = useCallback(() => {
             if (startDate && endDate) {
                 setAnchorEl(null);
-                onChange([
-                    moment(startDate).format("YYYY-MM-DD"),
-                    moment(endDate).format("YYYY-MM-DD"),
-                ]);
+                const momentStartDate = moment(startDate).format("YYYY-MM-DD");
+                const momentEndDate = moment(endDate).format("YYYY-MM-DD");
+
+                onChange([momentStartDate, momentEndDate]);
             }
         }, [endDate, onChange, startDate]);
 

--- a/src/webapp/components/table/statistic-table/useTableFilters.ts
+++ b/src/webapp/components/table/statistic-table/useTableFilters.ts
@@ -1,4 +1,6 @@
 import { useCallback, useMemo, useState } from "react";
+import moment from "moment";
+
 import _ from "../../../../domain/entities/generic/Collection";
 import { useAppContext } from "../../../contexts/app-context";
 import {
@@ -44,10 +46,13 @@ export const useTableFilters = (
                         if (filterValues.length === 0) {
                             return true;
                         } else if (isDatePickerFilter) {
-                            return row[key] && filterValues[0] && filterValues[1]
-                                ? filterValues[0] <= (row[key] || "") &&
-                                      (row[key] || "") <= filterValues[1]
-                                : true;
+                            if (!row[key] || !filterValues[0] || !filterValues[1]) return true;
+
+                            const start = moment(filterValues[0], "YYYY-MM-DD");
+                            const end = moment(filterValues[1], "YYYY-MM-DD");
+                            const target = moment(row[key], "MMMM D, YYYY");
+
+                            return target.isBetween(start, end, "day", "[]");
                         } else {
                             return filterValues.includes(row[key] || "");
                         }

--- a/src/webapp/pages/dashboard/useAlertsPerformanceOverview.ts
+++ b/src/webapp/pages/dashboard/useAlertsPerformanceOverview.ts
@@ -205,6 +205,7 @@ export function useAlertsPerformanceOverview(): State {
                 notifiedDate: getDateStringAsMonthYearString(data.notifiedDate),
                 respondedDate: getDateStringAsMonthYearString(data.respondedDate),
                 detectionDate: getDateStringAsMonthYearString(data.detectionDate),
+                date: getDateStringAsMonthYearString(data.date),
                 incidentManager: incidentManager?.name || data.incidentManager,
                 incidentManagerUsername: incidentManager?.username || "",
                 province: data.province.trim(),

--- a/src/webapp/pages/event-tracker/useMappedAlerts.ts
+++ b/src/webapp/pages/event-tracker/useMappedAlerts.ts
@@ -134,6 +134,7 @@ export function useMappedAlerts(diseaseOutbreakId: Id): State {
                 notifiedDate: getDateStringAsMonthYearString(data.notifiedDate),
                 respondedDate: getDateStringAsMonthYearString(data.respondedDate),
                 detectionDate: getDateStringAsMonthYearString(data.detectionDate),
+                date: getDateStringAsMonthYearString(data.date),
                 incidentManager: incidentManager?.name || data.incidentManager,
                 incidentManagerUsername: incidentManager?.username || "",
                 province: data.province.trim(),


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #869adjh0a [End Date for Duration Filter is Setting incorrectly](https://app.clickup.com/t/869adjh0a)

### :memo: Implementation

- [x] Fix Date picker independently of the time zone
- [x] Fix duration filter that was not working due to the date format in tables

### :video_camera: Screenshots/Screen capture

### :fire: Notes to the tester
- The problem was only in regions with negative timezones, so test it in your timezone and also set a negative timezone to check all ok
