### PR TITLE
Add to hardcoded disease options in front end the Chemical exposure disease

### DIFF
--- a/src/domain/entities/disease-outbreak-event/PerformanceOverviewMetrics.ts
+++ b/src/domain/entities/disease-outbreak-event/PerformanceOverviewMetrics.ts
@@ -20,6 +20,7 @@ export const diseaseNames = [
     "SARIs",
     "Typhoid fever",
     "Zika fever",
+    "Chemical Exposure (general)",
     UNCONFIRMABLE_DISEASE_NAME,
     UNKNOWN_DISEASE_NAME,
 ] as const;


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #8699hc48t [Add to hardcoded disease options in front end the Chemical exposure disease](https://app.clickup.com/t/8699hc48t)

### :memo: Implementation
- Add to hardcoded disease options in front end the Chemical exposure disease

### :video_camera: Screenshots/Screen capture

<img width="1598" height="916" alt="image" src="https://github.com/user-attachments/assets/5c63a559-4512-42a4-b239-542075f77782" />


### :fire: Notes to the tester
